### PR TITLE
RF: Stop adding a default @base to the context, use explicit prefix

### DIFF
--- a/datalad_metalad/__init__.py
+++ b/datalad_metalad/__init__.py
@@ -58,9 +58,8 @@ location_keys = ('dataset_info', 'content_info', 'filepath_info')
 default_context = {
     # schema.org definitions by default
     "@vocab": "http://schema.org/",
-    # resolve non-compact/absolute identifiers to the DataLad
-    # resolver
-    "@base": "http://dx.datalad.org/",
+    # DataLad ID prefix, pointing to our own resolver
+    "datalad": "http://dx.datalad.org/",
 }
 
 
@@ -328,11 +327,16 @@ def get_file_id(rec):
 
     Prefer a present annex key, but fall back on the Git shasum that is
     always around. Identify the GITSHA as such, and in a similar manner
-    to git-annex's style
+    to git-annex's style.
+
+    Any ID string is prefixed with 'datalad:' to identify it as a
+    DataLad-recognized ID. This prefix is defined in the main JSON-LD
+    context defintion.
     """
-    return rec['key'] if 'key' in rec else 'SHA1-s{}--{}'.format(
+    id_ = rec['key'] if 'key' in rec else 'SHA1-s{}--{}'.format(
         rec['bytesize'] if rec['type'] != 'symlink' else 0,
         rec['gitshasum'])
+    return 'datalad:{}'.format(id_)
 
 
 def get_agent_id(name, email):

--- a/datalad_metalad/extractors/core.py
+++ b/datalad_metalad/extractors/core.py
@@ -139,7 +139,7 @@ class DataladCoreExtractor(MetadataExtractor):
         for subds in [s for s in status if s['type'] == 'dataset']:
             subdsinfo = {
                 # reference by subdataset commit
-                '@id': subds['gitshasum'],
+                '@id': 'datalad:{}'.format(subds['gitshasum']),
                 '@type': 'Dataset',
                 'name': Path(subds['path']).relative_to(ds.pathobj).as_posix(),
             }
@@ -147,7 +147,7 @@ class DataladCoreExtractor(MetadataExtractor):
                 contains=subds['path'],
                 return_type='item-or-list').get('gitmodule_datalad-id', None)
             if subdsid:
-                subdsinfo['identifier'] = subdsid
+                subdsinfo['identifier'] = 'datalad:{}'.format(subdsid)
             parts.append(subdsinfo)
         if parts:
             meta['hasPart'] = parts
@@ -174,7 +174,7 @@ class DataladCoreExtractor(MetadataExtractor):
                 annex_uuid = ds.config.get(
                     'remote.{}.annex-uuid'.format(r), None)
                 if annex_uuid is not None:
-                    info['@id'] = annex_uuid
+                    info['@id'] = 'datalad:{}'.format(annex_uuid)
                     known_uuids[annex_uuid] = info
                 if 'url' in info or '@id' in info:
                     # only record if we have any identifying information

--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -147,8 +147,9 @@ def test_report(path, orig):
         res[0]['metadata']['metalad_core']
     )
     assert_in(
-        {'@type': 'Dataset', '@id': subds.repo.get_hexsha(),
-         'identifier': subds.id, 'name': 'sub'},
+            {'@type': 'Dataset',
+            '@id': 'datalad:{}'.format(subds.repo.get_hexsha()),
+            'identifier': 'datalad:{}'.format(subds.id), 'name': 'sub'},
         core_dsmeta['hasPart']
     )
     # has not seen the content


### PR DESCRIPTION
Now all IDs from the DataLad realm come with a 'datalad:' prefix, and a matching definition in the context.

This is safer (no accidental false-positives), and more compatible with using DataLad IDs in the context of 3rd-party metadata schemes.