### PR TITLE
ENH: Let `custom` extractor inject dataset/file IDs if not present

### DIFF
--- a/datalad_metalad/__init__.py
+++ b/datalad_metalad/__init__.py
@@ -2,6 +2,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import os
 from .version import __version__
 from collections import (
     Mapping,
@@ -13,6 +14,7 @@ from datalad.utils import (
     PurePosixPath,
 )
 from datalad.consts import PRE_INIT_COMMIT_SHA
+from datalad.support.digests import Digester
 
 
 # defines a datalad command suite
@@ -349,8 +351,11 @@ def get_file_id(rec):
     context defintion.
     """
     id_ = rec['key'] if 'key' in rec else 'SHA1-s{}--{}'.format(
-        rec['bytesize'] if rec['type'] != 'symlink' else 0,
-        rec['gitshasum'])
+        rec['bytesize'] if 'bytesize' in rec
+        else 0 if rec['type'] == 'symlink'
+        else os.stat(rec['path']).st_size,
+        rec['gitshasum'] if 'gitshasum' in rec
+        else Digester(digests=['sha1'])(rec['path'])['sha1'])
     return 'datalad:{}'.format(id_)
 
 

--- a/datalad_metalad/extractors/custom.py
+++ b/datalad_metalad/extractors/custom.py
@@ -32,6 +32,7 @@ from datalad.utils import (
     Path,
     PurePosixPath,
 )
+from .. import get_file_id
 
 
 class CustomMetadataExtractor(MetadataExtractor):
@@ -78,6 +79,13 @@ class CustomMetadataExtractor(MetadataExtractor):
                 if meta_fpath is not None and op.exists(meta_fpath):
                     try:
                         meta = jsonload(text_type(meta_fpath))
+                        if isinstance(meta, dict) and meta \
+                                and '@id' not in meta:
+                            # in case we have a single, top-level
+                            # document, and it has no ID: assume that
+                            # it describes the file and assign the
+                            # datalad file ID
+                            meta['@id'] = get_file_id(rec)
                         if meta:
                             yield dict(
                                 path=rec['path'],
@@ -178,6 +186,8 @@ def _yield_dsmeta(ds):
         meta = jsonload(text_type(abssrcfile))
         dsmeta.update(meta)
     if dsmeta:
+        if '@id' not in dsmeta:
+            dsmeta['@id'] = ds.id
         yield dict(
             path=ds.path,
             metadata=dsmeta,

--- a/datalad_metalad/extractors/tests/test_custom.py
+++ b/datalad_metalad/extractors/tests/test_custom.py
@@ -97,6 +97,8 @@ testmeta = {
             'customloc': jsondumps(testmeta)}})
 def test_custom_dsmeta(path):
     ds = Dataset(path).create(force=True)
+    sample_jsonld_ = dict(sample_jsonld)
+    sample_jsonld_.update({'@id': ds.id})
     # enable custom extractor
     # use default location
     ds.config.add('datalad.metadata.nativetype', 'metalad_custom', where='dataset')
@@ -108,8 +110,7 @@ def test_custom_dsmeta(path):
     assert_result_count(res, 1)
     dsmeta = res[0]['metadata']
     assert_in('metalad_custom', dsmeta)
-    eq_(sample_jsonld, dsmeta['metalad_custom'])
-    assert_not_in('@id', dsmeta['metalad_custom'])
+    eq_(sample_jsonld_, dsmeta['metalad_custom'])
 
     # overwrite default source location within something non-exiting
     # extraction does not blow up, but no metadata is reported
@@ -187,7 +188,12 @@ def test_custom_contentmeta(path):
         path=text_type(ds.pathobj / 'sub' / 'one'),
         type='file',
         status='ok',
-        metadata={'metalad_custom': {'some': 'thing'}},
+        metadata={
+            'metalad_custom': {
+                'some': 'thing',
+                "@id": "datalad:MD5E-s1--c4ca4238a0b923820dcc509a6f75849b",
+            }
+        },
         action='meta_extract'
     )
 

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -740,6 +740,11 @@ def test_unique_values(path):
     eq_(
         ucm['metalad_custom'],
         {
+            '@id': [
+                'datalad:MD5E-s1--c4ca4238a0b923820dcc509a6f75849b',
+                'datalad:MD5E-s1--c81e728d9d4c2f636f067f89cc14862c',
+                'datalad:MD5E-s1--eccbc87e4b5ce2fe28308fd9f2a7baf3',
+            ],
             # complex types do not get shmooshed together
             "complextype": [
                 {

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -36,6 +36,7 @@ sample_dsmeta = {
     "description": "Storm Data is provided by the NWS",
 }
 sample_fmeta = {
+    '@id': 'datalad:SHA1-s1--356a192b7913b04c54574d18c28d46e6395428ab',
     "something": "stupid",
     "complextype": {
         "entity": {


### PR DESCRIPTION
This will dramatically ease the homogenization of metadata across
sources, because uniform IDs can be used to match metadata documents
across sources.