### PR TITLE
disable re-extraction without sacrificing top-level updates

### DIFF
--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -467,14 +467,17 @@ def _extractor_changed(ds, ds_db, exinfo, path):
     # check recorded states in src and dst vs. "current"
     if (
             # old aggregate catalog with a plain extractor name list
+            # Adina: this can be None if the super ds aggregate_v1.json does
+            # not contain an entry for the subdataset - is that desired?
             not isinstance(exstate_rec, dict) \
             or sorted(exinfo.keys()) != sorted(exstate_rec.keys()) \
-            or any(exinfo[k]['state'] != exstate_rec[k]
+            or any(sorted(exinfo[k]['state']) != sorted(exstate_rec[k])
                    for k in exinfo)
          ):
 
         lgr.debug('Difference between recorded and current extractor detected in %s (was: %s; is: %s)',
-                  ds, exstate_rec, exinfo.get('state', None))
+                  ds, exstate_rec, exinfo)
+
         return True
     return False
 

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -863,6 +863,14 @@ def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
                     if Path(aggds) == subj \
                     or subj in Path(aggds).parents
                 )
+
+                # we know there is up-to-date meta data in subj (where we want
+                # metadata from), but if the top has not seen this meta data before,
+                # there is no record in top_agginfo_db about it. Let's get it into
+                # subj to not extract it again
+                if subj not in top_agginfo_db:
+                    subjs.append(Dataset(subj))
+
             else:
                 subjs.append(subj)
 

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -771,8 +771,15 @@ def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
         # Now, do the extraction if needed
         if not use_self_aggregate and (force == 'extraction' or (
                 (have_diff_top or last_refcommit_top is None) and
-                (have_diff_src or last_refcommit_src is None))):
-
+                (have_diff_src or last_refcommit_src is None)) or
+                (have_diff_top and not have_diff_src and
+                         last_refcommit_src == last_refcommit_top)):
+        # Adina: The last condition should only be true for a recursive aggregation
+        # with a changed subdataset that has up-to-date meta data: There is a diff
+        # between refcommit in Top and current state of top, ref commits of source
+        # and top are identical. Previously, lack of this condition was the
+        # reason why top dataset content info did not get reaggregated
+        # https://github.com/datalad/datalad-metalad/pull/21/commits/26a56551c665380362f13022030cacdd602fc7d8#r377609152)
             lgr.debug(
                 'Extract metadata from %s '
                 '(use_self_aggregate=%s, force=%s, last_refcommit=%s, '

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -526,6 +526,8 @@ def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
                 process_type='extractors',
                 result_renderer='disabled')
         }
+        ##Adina: this checks whether there is a json dict for subds in super,
+        ##is None when never aggregated from sub into top, thus not a dict
         exstate_rec = top_agginfo_db.get(
             aggsrc.pathobj, {}).get('extractors', None)
         if (

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -161,7 +161,7 @@ class Aggregate(Interface):
         dataset=Parameter(
             args=("-d", "--dataset"),
             doc="""topmost dataset metadata will be aggregated into. If no
-            dataset is specified, a datasets will be discovered based on the
+            dataset is specified, a dataset will be discovered based on the
             current working directory.""",
             constraints=EnsureDataset() | EnsureNone()),
         path=Parameter(
@@ -214,7 +214,7 @@ class Aggregate(Interface):
         # path args could be
         # - installed datasets
         # - names of pre-aggregated dataset that are not around
-        # - -like status they should match anything underneath them
+        # - like status they should match anything underneath them
 
         # Step 1: figure out which available dataset is closest to a given path
         if path:
@@ -255,7 +255,7 @@ class Aggregate(Interface):
             # pass arg in as-is to get proper argument semantics
             dataset=dataset,
             # query on all paths to get desired result with recursion
-            # enables
+            # enabled
             path=path,
             # never act on anything untracked, we cannot record its identity
             untracked='no',
@@ -448,7 +448,7 @@ class Aggregate(Interface):
 def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
     """Internal helper
 
-    Performs non-recursive aggergation for a single dataset.
+    Performs non-recursive aggregation for a single dataset.
 
     Parameters
     ----------
@@ -529,7 +529,7 @@ def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
         exstate_rec = top_agginfo_db.get(
             aggsrc.pathobj, {}).get('extractors', None)
         if (
-                # old aggregate catalag with a plain extractor name list
+                # old aggregate catalogue with a plain extractor name list
                 not isinstance(exstate_rec, dict) \
                 or sorted(exinfo.keys()) != sorted(exstate_rec.keys()) \
                 or any(exinfo[k]['state'] != exstate_rec[k]

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -1034,6 +1034,7 @@ def _do_top_aggregation(ds, extract_from_ds, force, vanished_datasets, cache):
                    for objtype in ('dataset_info', 'content_info'))
                for d, dinfo in iteritems(top_agginfo_db))
     ]
+    lgr.debug("Obsolete objects are: %s", obsolete_objs)
     for obsolete_obj in obsolete_objs:
         # remove from the object store
         # there is no need to fiddle with `remove()`, save will do that

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -656,6 +656,22 @@ def test_reaggregate(path):
     # we should see three deletions, two for the replaced metadata blobs
     # of the modified subdataset, and one for the dataset metadata of the super
     assert_result_count(res, 3, action='delete')
+
+    # Note: This currently fails. Via python API the results have only
+    #  - two "deleted"
+    #  - two "meta_extract; notneeded"
+    #  - three "added"
+    # Via CLI with "-d ." however, there are
+    #  - three deleted
+    #  - no results fromextract whatsoever
+    #  - four "added"
+    # So this would be correct according to the following assertions.
+    # Via CLI without "-d ." we get the same as here via python. How does this make sense?
+    # If anything ds.meta_aggregate() should be identical to `datalad meta-aggregate -d .`, no?
+
+    # Also note, that "added" results should indeed be one more than deleted, I think (aggregate.json)
+
+
     # four additions: two new blobs for the subdataset, one dataset
     # metadata blob for the root, due to a new modification date
     # and the aggregate catalog
@@ -847,14 +863,22 @@ def test_aggregate_into_top_no_extraction(path):
     path = Path(path)
     superds = Dataset(path).create()
     subds = superds.create(path / 'sub')
-    # put a single (empty) file in origds to have some metadata-relevant
+    # put a single (empty) file in subds to have some metadata-relevant
     # content
     payload = subds.pathobj / 'CONTENT'
     payload.write_text(u'some')
     superds.save(recursive=True)
     assert_repo_status(superds.path)
     # have metadata aggregated in the subds
-    subds.meta_aggregate()
+
+    import pdb; pdb.set_trace()
+
+    print("\n######### Aggregate within source dataset:\n")
+
+
+    res = subds.meta_aggregate()
+
+    print("\n######### Aggregate within source dataset (2nd time):\n")
 
     # FTR: Doing it again, yields extraction not needed:
     assert_result_count(subds.meta_aggregate(),
@@ -879,12 +903,12 @@ def test_aggregate_into_top_no_extraction(path):
     assert_result_count(res, 1, type='dataset')
     assert_result_count(res, 1, type='file')
 
+    print("\n######### Aggregate into top dataset:\n")
+
     # Now, aggregate into top
     res = superds.meta_aggregate('sub/', into='top')
     # super should now be able to report:
-    assert_status('ok',
-                  superds.meta_dump('sub/', on_failure='ignore')
-                  )
+    assert_status('ok', superds.meta_dump('sub/', on_failure='ignore'))
     # Re-extraction should not be required:
     assert_result_count(res, 1,
                         action='meta_extract',

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -839,3 +839,55 @@ def test_aggregate_aggregation(path):
             )[0]['metadata']['metalad_core']['contentbytesize'],
         6
     )
+
+# Test for https://github.com/datalad/datalad-metalad/issues/20
+@with_tempfile(mkdir=True)
+def test_aggregate_into_top_no_extraction(path):
+
+    path = Path(path)
+    superds = Dataset(path).create()
+    subds = superds.create(path / 'sub')
+    # put a single (empty) file in origds to have some metadata-relevant
+    # content
+    payload = subds.pathobj / 'CONTENT'
+    payload.write_text(u'some')
+    superds.save(recursive=True)
+    assert_repo_status(superds.path)
+    # have metadata aggregated in the subds
+    subds.meta_aggregate()
+
+    # FTR: Doing it again, yields extraction not needed:
+    assert_result_count(subds.meta_aggregate(),
+                        1,
+                        action='meta_extract',
+                        status='notneeded',
+                        type='dataset'
+                        )
+
+    # update subds entry in super
+    superds.save(recursive=True)
+    # super has no metadata on sub's content
+    assert_status(
+        'impossible',
+        superds.meta_dump('sub/', on_failure='ignore')
+    )
+
+    # but subds has
+    res = subds.meta_dump('.', on_failure='ignore')
+    assert_result_count(res, 2)
+    assert_result_count(res, 2, status='ok')
+    assert_result_count(res, 1, type='dataset')
+    assert_result_count(res, 1, type='file')
+
+    # Now, aggregate into top
+    res = superds.meta_aggregate('sub/', into='top')
+    # super should now be able to report:
+    assert_status('ok',
+                  superds.meta_dump('sub/', on_failure='ignore')
+                  )
+    # Re-extraction should not be required:
+    assert_result_count(res, 1,
+                        action='meta_extract',
+                        status='notneeded',
+                        type='dataset'
+                        )

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -656,22 +656,6 @@ def test_reaggregate(path):
     # we should see three deletions, two for the replaced metadata blobs
     # of the modified subdataset, and one for the dataset metadata of the super
     assert_result_count(res, 3, action='delete')
-
-    # Note: This currently fails. Via python API the results have only
-    #  - two "deleted"
-    #  - two "meta_extract; notneeded"
-    #  - three "added"
-    # Via CLI with "-d ." however, there are
-    #  - three deleted
-    #  - no results fromextract whatsoever
-    #  - four "added"
-    # So this would be correct according to the following assertions.
-    # Via CLI without "-d ." we get the same as here via python. How does this make sense?
-    # If anything ds.meta_aggregate() should be identical to `datalad meta-aggregate -d .`, no?
-
-    # Also note, that "added" results should indeed be one more than deleted, I think (aggregate.json)
-
-
     # four additions: two new blobs for the subdataset, one dataset
     # metadata blob for the root, due to a new modification date
     # and the aggregate catalog
@@ -871,14 +855,7 @@ def test_aggregate_into_top_no_extraction(path):
     assert_repo_status(superds.path)
     # have metadata aggregated in the subds
 
-    import pdb; pdb.set_trace()
-
-    print("\n######### Aggregate within source dataset:\n")
-
-
     res = subds.meta_aggregate()
-
-    print("\n######### Aggregate within source dataset (2nd time):\n")
 
     # FTR: Doing it again, yields extraction not needed:
     assert_result_count(subds.meta_aggregate(),
@@ -895,16 +872,12 @@ def test_aggregate_into_top_no_extraction(path):
         'impossible',
         superds.meta_dump('sub/', on_failure='ignore')
     )
-
     # but subds has
     res = subds.meta_dump('.', on_failure='ignore')
     assert_result_count(res, 2)
     assert_result_count(res, 2, status='ok')
     assert_result_count(res, 1, type='dataset')
     assert_result_count(res, 1, type='file')
-
-    print("\n######### Aggregate into top dataset:\n")
-
     # Now, aggregate into top
     res = superds.meta_aggregate('sub/', into='top')
     # super should now be able to report:


### PR DESCRIPTION
This sits on top of #21 and attempts to fix #20.

I found two issues:
- (as Ben also noted) There was no condition which could do what is desired. I.e, whenever a subds had up-to-date metadata, but its meta data was unknown to the top, re-extraction in sub was enforced. I have added a switch to use pre-aggregated metadata (from the sub) even if sub's metadata was never aggregated to the top yet. After all this digging, it feels like a too-cheap solution to not have catastrophic consequences at one point, but for now the tests work (at least locally. Also Ben's new test)... But please check ;-)
- A change in #21 prevented an update of top's dataset info in the case of re-using sub's meta data that the top did not yet have, which let to the test failures Ben observed, I believe (see [here](https://github.com/datalad/datalad-metalad/pull/21/commits/26a56551c665380362f13022030cacdd602fc7d8#r377609152)  for a full explanation). I have also added a conditional to allow extraction in top for these cases, and tests pass now (at least locally)

The PR isn't really cleaned up yet and still contains all of Bens debugging notes, but I wanted to get Feedback on my approach first. If what I did is sensible, I can clean this up.