### PR TITLE
TST: remove Python 2.7 from testing environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
   - 3.6
 


### PR DESCRIPTION
DataLad requires 3.5 or higher.