### PR TITLE
BF: fix whitespace handling in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ clean:
 
 bin:
 	mkdir -p $@
-	PYTHONPATH=bin:$(PYTHONPATH) python setup.py develop --install-dir $@
+	PYTHONPATH="bin:$(PYTHONPATH)" python setup.py develop --install-dir $@
 
 test-code: bin
-	PATH=bin:$(PATH) PYTHONPATH=bin:$(PYTHONPATH) $(NOSETESTS) -s -v $(MODULE)
+	PATH="bin:$(PATH)" PYTHONPATH="bin:$(PYTHONPATH)" $(NOSETESTS) -s -v $(MODULE)
 
 test-coverage:
 	rm -rf coverage .coverage


### PR DESCRIPTION
Same fix as in datalad. Handle whitespace in shell variable expansion properly