### PR TITLE
TST: Prefer datalad-test over localhost as SSH target

### DIFF
--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -407,7 +407,7 @@ def test_publish_aggregated(path):
     spath = op.join(path, 'remote')
     base.create_sibling(
         name="local_target",
-        sshurl="ssh://localhost",
+        sshurl="ssh://datalad-test",
         target_dir=spath)
     base.publish('.', to='local_target', transfer_data='all')
     remote = Dataset(spath)


### PR DESCRIPTION
With datalad/datalad#4762, DataLad's tests have removed the use of
localhost as the target so that a Docker-based target [0] can more
easily be swapped in.  Use datalad-test here too.  It will work with
the current .travis.yml setup, where datalad-test points to localhost,
and will allow the Docker target to be used with the -metalad build at
datalad-extensions [1].

[0] https://hub.docker.com/r/dataladtester/docker-ssh-target
[1] https://github.com/datalad/datalad-extensions/pull/27#issuecomment-668217294