### PR TITLE
TST: test_api_{annex,git}: Use annex instead of no_annex

### DIFF
--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -40,8 +40,8 @@ from ...tests import (
 
 
 @with_tree(tree={'file.dat': ''})
-def check_api(no_annex, path):
-    ds = Dataset(path).create(force=True, no_annex=no_annex)
+def check_api(annex, path):
+    ds = Dataset(path).create(force=True, annex=annex)
     ds.save()
     assert_repo_status(ds.path)
 
@@ -87,11 +87,11 @@ def check_api(no_annex, path):
 
 def test_api_git():
     # should tollerate both pure git and annex repos
-    yield check_api, True
+    yield check_api, False
 
 
 def test_api_annex():
-    yield check_api, False
+    yield check_api, True
 
 
 @with_tempfile(mkdir=True)


### PR DESCRIPTION
create's no_annex was deprecated in v0.13.0.

---

If this goes in as is, the required version for datalad would need to be bumped.