### PR TITLE
Nf meta add

### DIFF
--- a/datalad_metalad/__init__.py
+++ b/datalad_metalad/__init__.py
@@ -42,6 +42,12 @@ command_suite = (
             'meta-aggregate',
             'meta_aggregate'
         ),
+        (
+            'datalad_metalad.add',
+            'Add',
+            'meta-add',
+            'meta_add'
+        ),
     ]
 )
 

--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -101,15 +101,15 @@ class Add(Interface):
 
 
       Add metadata stored in the file "metadata-123.json" to the
-      metadata stored in the git-repository "/metadata/dataset_0".
+      metadata stored in the git-repository "/home/user/dataset_0".
 
-      $ datalad meta-add --metadata-store /metadata/dataset_0 metadata-123.json
+      $ datalad meta-add --metadata-store /home/user/dataset_0 metadata-123.json
 
       Add metadata stored in the file "metadata-123.json" to the
       metadata model instance in the current directory and overwrite
       the "dataset_id" value stored in "metadata-123.json".
 
-      $ datalad meta-add --metadata-store /metadata/dataset_0 metadata-123.json \
+      $ datalad meta-add --metadata-store /home/user/dataset_0 metadata-123.json \
        '{"dataset_id": "00010203-1011-2021-3031-404142434445}'
 
       Add metadata read from standard input to the metadata model
@@ -124,7 +124,7 @@ class Add(Interface):
       directory and overwrite metadata values with the values stored in
       stored in "extra-info.json".
 
-      $ datalad meta-add --metadata-store /metadata/dataset_0 \
+      $ datalad meta-add --metadata-store /home/user/dataset_0 \
        metadata-123.json @extra-info.json
 
     """

--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -1,0 +1,450 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""
+Add metadata to a metadata model instance.
+Metadata is usually provided by an extractor, but
+can also be created by other means.
+"""
+import json
+import logging
+import sys
+from itertools import chain
+from os import curdir
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from dataclasses import dataclass
+
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+from datalad.interface.utils import eval_results
+from datalad.distribution.dataset import datasetmethod
+
+from datalad.support.constraints import EnsureBool
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr
+)
+from datalad.support.param import Parameter
+
+from dataladmetadatamodel.common import get_top_nodes_and_metadata_root_record
+from dataladmetadatamodel.connector import Connector
+from dataladmetadatamodel.filetree import FileTree
+from dataladmetadatamodel.mapper.gitmapper.objectreference import \
+    flush_object_references
+from dataladmetadatamodel.mapper.gitmapper.utils import lock_backend, \
+    unlock_backend
+from dataladmetadatamodel.metadata import ExtractorConfiguration, Metadata
+from dataladmetadatamodel.metadatapath import MetadataPath
+from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
+from dataladmetadatamodel.metadatasource import ImmediateMetadataSource
+
+from .exceptions import MetadataKeyException
+
+__docformat__ = "restructuredtext"
+
+default_mapper_family = "git"
+
+lgr = logging.getLogger("datalad.metadata.add")
+
+
+@dataclass
+class AddParameter:
+    dataset_id: UUID
+    dataset_version: str
+    file_path: MetadataPath
+
+    root_dataset_id: Optional[UUID]
+    root_dataset_version: Optional[str]
+    dataset_tree_path: Optional[MetadataPath]
+
+    extractor_name: str
+    extractor_version: str
+    extraction_time: float
+    extraction_parameter: Dict[str, str]
+    agent_name: str
+    agent_email: str
+
+    extracted_metadata: dict
+
+
+@build_doc
+class Add(Interface):
+    r"""Add metadata to metadata model instance.
+
+    This command reads metadata from a source and adds this metadata
+    to a metadata model instance. A source can be: arguments, standard
+    input, or a local file. The metadata format is a strings with the
+    JSON-serialized dictionary that describes the metadata
+
+    [TODO: add a schema]
+
+    If metadata is read from a source, parameter can overwrite or
+    amend information that is stored in the source.
+
+    Examples:
+
+      Add metadata stored in the file "metadata-123.json" to the
+      metadata model instance in the current directory.
+
+      $ datalad meta-add metadata-123.json
+
+
+      Add metadata stored in the file "metadata-123.json" to the
+      metadata stored in the git-repository "/metadata/dataset_0".
+
+      $ datalad meta-add --metadata-store /metadata/dataset_0 metadata-123.json
+
+      Add metadata stored in the file "metadata-123.json" to the
+      metadata model instance in the current directory and overwrite
+      the "dataset_id" value stored in "metadata-123.json".
+
+      $ datalad meta-add --metadata-store /metadata/dataset_0 metadata-123.json \
+       '{"dataset_id": "00010203-1011-2021-3031-404142434445}'
+
+      Add metadata read from standard input to the metadata model
+      instance in the current directory.
+
+      $ datalad meta-add -
+
+      All arguments can be pre-fixed by '@', in which case the pre-fixed
+      argument is interpreted as a file-name and the argument value is read
+      from the file. For example, add metadata stored in the file
+      "metadata-123.json" to the metadata model instance in the current
+      directory and overwrite metadata values with the values stored in
+      stored in "extra-info.json".
+
+      $ datalad meta-add --metadata-store /metadata/dataset_0 \
+       metadata-123.json @extra-info.json
+
+    """
+
+    required_keys = (
+        "extractor_name",
+        "extractor_version",
+        "extraction_parameter",
+        "extraction_time",
+        "agent_name",
+        "agent_email",
+        "dataset_id",
+        "dataset_version",
+        "extracted_metadata")
+
+    optional_keys = (
+        "intra_dataset_path",)
+
+    required_additional_keys = (
+        "root_dataset_id",
+        "root_dataset_version",
+        "inter_dataset_path")
+
+    required_keys_lines = "\n".join(map(repr, required_keys))
+    required_additional_keys_lines = "\n".join(
+        map(repr, required_additional_keys))
+
+    _params_ = dict(
+            metadata=Parameter(
+            args=("metadata",),
+            metavar="METADATA",
+            doc=f"""Path of a file that contains the metadata that
+            should be added to the metadata model instance (the
+            metadata must be provided as a JSON-serialized metadata
+            dictionary).
+            
+            If the path is "-", metadata is read from standard input.
+            
+            The dictionary must contain the following keys:
+            
+            {required_keys_lines}
+            
+            If the metadata is associated with a file, the following key
+            indicates the file path:
+            
+            'intra_dataset_path'
+            
+            It may in addition contain either all or none of the
+            following keys (they are used to add metadata element
+            as a sub-dataset element, i.e. perform aggregation):
+            
+            {required_additional_keys_lines}            
+            """,
+            constraints=EnsureStr() | EnsureNone()),
+        metadata_store=Parameter(
+            args=("-s", "--metadata-store"),
+            doc="""Directory in which the metadata model instance is
+            stored. If no directory name is provided, the current working
+            directory is used.""",
+            constraints=EnsureStr() | EnsureNone()),
+        additionalvalues=Parameter(
+            args=("additionalvalues",),
+            metavar="ADDITIONAL_VALUES",
+            doc="""A string that contains a JSON serialized dictionary of
+            key value-pairs. These key values-pairs are used in addition to
+            the key value pairs in the metadata dictionary to describe
+            the metadata that should be added. If an additional key is
+            already present in the metadata, it will override the value
+            from metadata. In this case a warning is issued.""",
+            nargs="?",
+            constraints=EnsureStr() | EnsureNone()),
+        allow_override=Parameter(
+            args=("-o", "--allow-override"),
+            doc="""Allow the additional values to override values given in
+            metadata.""",
+            default=False,
+            constraints=EnsureBool() | EnsureNone()),
+        allow_unknown=Parameter(
+            args=("-u", "--allow-unknown"),
+            doc="""Allow unknown keys. By default, unknown keys generate
+            an errors. If this switch is True, unknown keys will only be
+            reported.""",
+            default=False,
+            constraints=EnsureBool() | EnsureNone()))
+
+    @staticmethod
+    @datasetmethod(name="meta_add")
+    @eval_results
+    def __call__(
+            metadata: str,
+            metadata_store: Optional[str] = None,
+            additionalvalues: Optional[List[str]] = None,
+            allow_override: bool = False,
+            allow_unknown: bool = False):
+
+        if metadata == "-":
+            metadata_file = sys.stdin
+        else:
+            metadata_file = open(metadata, "tr")
+
+        metadata_store = Path(metadata_store or curdir)
+        metadata = process_parameters(
+            json.load(metadata_file),
+            json.loads(additionalvalues or "{}"),
+            allow_override=allow_override,
+            allow_unknown=allow_unknown)
+
+        add_parameter = AddParameter(
+            dataset_id=UUID(metadata["dataset_id"]),
+            dataset_version=metadata["dataset_version"],
+            file_path=(
+                MetadataPath(metadata["intra_dataset_path"])
+                if "intra_dataset_path" in metadata
+                else None),
+
+            root_dataset_id=(
+                UUID(metadata["root_dataset_id"])
+                if "root_dataset_id" in metadata
+                else None),
+            root_dataset_version=metadata.get("root_dataset_version", None),
+            dataset_tree_path=MetadataPath(
+                metadata.get("inter_dataset_path", "")),
+
+            extractor_name=metadata["extractor_name"],
+            extractor_version=metadata["extractor_version"],
+            extraction_time=metadata["extraction_time"],
+            extraction_parameter=metadata["extraction_parameter"],
+            agent_name=metadata["agent_name"],
+            agent_email=metadata["agent_email"],
+
+            extracted_metadata=metadata["extracted_metadata"])
+
+        # If the key "intra_dataset_path" is present in the metadata
+        # dictionary, we assume that the metadata-dictionary describes
+        # file-level metadata. Otherwise, we assume that the
+        # metadata-dictionary contains dataset-level metadata.
+        if add_parameter.file_path:
+            yield from add_file_metadata(metadata_store, add_parameter)
+        else:
+            yield from add_dataset_metadata(metadata_store, add_parameter)
+        return
+
+
+def process_parameters(metadata: dict,
+                       additional_values: dict,
+                       allow_override: bool,
+                       allow_unknown: bool):
+
+    overridden_keys = [
+        key
+        for key in additional_values
+        if key in metadata]
+
+    if overridden_keys:
+        if allow_override is False:
+            raise MetadataKeyException(
+                "Keys overridden by additional values",
+                overridden_keys)
+        lgr.info(
+            "keys overridden in additional values: "
+            + ", ".join(overridden_keys))
+
+    # Combine keys
+    metadata = {
+        **metadata,
+        **additional_values
+    }
+
+    # Check existence of required keys
+    missing_keys = [
+        key
+        for key in Add.required_keys
+        if key not in metadata]
+
+    if missing_keys:
+        raise MetadataKeyException(
+            "Missing keys",
+            missing_keys)
+
+    # Check completeness of non-mandatory keys
+    non_mandatory_keys = [
+        key
+        for key in Add.required_additional_keys
+        if key in metadata]
+
+    if non_mandatory_keys:
+        non_mandatory_missing_keys = [
+            key
+            for key in Add.required_additional_keys
+            if key not in metadata]
+
+        if non_mandatory_missing_keys:
+            raise MetadataKeyException(
+                "Non mandatory keys missing",
+                non_mandatory_missing_keys)
+
+    # Check for unknown keys:
+    unknown_keys = [
+        key
+        for key in metadata
+        if key not in chain(
+            Add.required_keys,
+            Add.required_additional_keys,
+            Add.optional_keys)]
+
+    if unknown_keys:
+        if not allow_unknown:
+            raise MetadataKeyException("Unknown keys", unknown_keys)
+        lgr.warning("Unknown keys in metadata: " + ", ".join(unknown_keys))
+
+    return metadata
+
+
+def _get_top_nodes(realm: str, ap: AddParameter):
+
+    if ap.root_dataset_id is None:
+        return get_top_nodes_and_metadata_root_record(
+            default_mapper_family,
+            realm,
+            ap.dataset_id,
+            ap.dataset_version,
+            MetadataPath(""),
+            auto_create=True)
+
+    tree_version_list, uuid_set, mrr = get_top_nodes_and_metadata_root_record(
+        default_mapper_family,
+        realm,
+        ap.root_dataset_id,
+        ap.root_dataset_version,
+        MetadataPath(""),
+        auto_create=True)
+
+    _, dataset_tree = tree_version_list.get_dataset_tree(
+        ap.root_dataset_version)
+
+    if ap.dataset_tree_path in dataset_tree:
+        mrr = dataset_tree.get_metadata_root_record(ap.dataset_tree_path)
+        assert mrr.dataset_identifier == ap.dataset_id
+    else:
+        dataset_level_metadata = Metadata(default_mapper_family, realm)
+        file_tree = FileTree(default_mapper_family, realm)
+        mrr = MetadataRootRecord(
+            default_mapper_family,
+            realm,
+            ap.dataset_id,
+            ap.dataset_version,
+            Connector.from_object(dataset_level_metadata),
+            Connector.from_object(file_tree))
+        dataset_tree.add_dataset(ap.dataset_tree_path, mrr)
+    return tree_version_list, uuid_set, mrr
+
+
+def add_file_metadata(metadata_store: Path, ap: AddParameter):
+
+    realm = str(metadata_store)
+    lock_backend(realm)
+
+    tree_version_list, uuid_set, mrr = _get_top_nodes(realm, ap)
+
+    file_tree = mrr.get_file_tree()
+    if file_tree is None:
+        file_tree = FileTree(default_mapper_family, realm)
+        mrr.set_file_tree(file_tree)
+
+    if ap.file_path in file_tree:
+        file_level_metadata = file_tree.get_metadata(ap.file_path)
+    else:
+        file_level_metadata = Metadata(default_mapper_family, realm)
+        file_tree.add_metadata(ap.file_path, file_level_metadata)
+
+    add_metadata_content(file_level_metadata, ap)
+
+    tree_version_list.save()
+    uuid_set.save()
+    flush_object_references(realm)
+
+    unlock_backend(realm)
+
+    yield {
+        "status": "ok",
+        "action": "add",
+        "type": "file",
+        "message": "added file metadata"
+    }
+    return
+
+
+def add_dataset_metadata(metadata_store: Path, ap: AddParameter):
+
+    realm = str(metadata_store)
+    lock_backend(realm)
+
+    tree_version_list, uuid_set, mrr = _get_top_nodes(realm, ap)
+
+    dataset_level_metadata = mrr.get_dataset_level_metadata()
+    if dataset_level_metadata is None:
+        dataset_level_metadata = Metadata(default_mapper_family, realm)
+        mrr.set_dataset_level_metadata(dataset_level_metadata)
+
+    add_metadata_content(dataset_level_metadata, ap)
+
+    tree_version_list.save()
+    uuid_set.save()
+    flush_object_references(realm)
+
+    unlock_backend(realm)
+
+    yield {
+        "status": "ok",
+        "action": "add",
+        "type": "dataset",
+        "message": "added dataset metadata"
+    }
+    return
+
+
+def add_metadata_content(metadata: Metadata, ap: AddParameter):
+    metadata.add_extractor_run(
+        ap.extraction_time,
+        ap.extractor_name,
+        ap.agent_name,
+        ap.agent_email,
+        ExtractorConfiguration(
+            ap.extractor_version,
+            ap.extraction_parameter),
+        ImmediateMetadataSource(ap.extracted_metadata))

--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -44,7 +44,6 @@ from dataladmetadatamodel.mapper.gitmapper.utils import lock_backend, \
 from dataladmetadatamodel.metadata import ExtractorConfiguration, Metadata
 from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
-from dataladmetadatamodel.metadatasource import ImmediateMetadataSource
 
 from .exceptions import MetadataKeyException
 
@@ -447,4 +446,4 @@ def add_metadata_content(metadata: Metadata, ap: AddParameter):
         ExtractorConfiguration(
             ap.extractor_version,
             ap.extraction_parameter),
-        ImmediateMetadataSource(ap.extracted_metadata))
+        ap.extracted_metadata)

--- a/datalad_metalad/exceptions.py
+++ b/datalad_metalad/exceptions.py
@@ -1,0 +1,24 @@
+from typing import List, Optional
+
+from datalad.utils import ensure_unicode
+
+
+class MetadataKeyException(RuntimeError):
+    def __init__(self,
+                 message: str = "",
+                 keys: Optional[List[str]] = None):
+
+        RuntimeError.__init__(self, message)
+        self.message = message
+        self.keys = keys or []
+
+    def to_str(self):
+        return (
+            "MetadataKeyException("
+            + ensure_unicode(self.message)
+            + ": "
+            + ", ".join(map(ensure_unicode, self.keys))
+            + ")")
+
+    def __str__(self):
+        return self.to_str()

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -1,0 +1,326 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# -*- coding: utf-8 -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test metadata adding"""
+import json
+import tempfile
+from typing import List
+from unittest.mock import patch
+from uuid import UUID
+
+from datalad.api import meta_add
+from datalad.support.gitrepo import GitRepo
+from datalad.tests.utils import (
+    assert_is_not_none,
+    assert_result_count,
+    assert_true,
+    eq_,
+    with_tempfile
+)
+
+from dataladmetadatamodel.common import get_top_nodes_and_metadata_root_record
+from dataladmetadatamodel.metadatapath import MetadataPath
+
+from ..exceptions import MetadataKeyException
+
+
+metadata_template = {
+    "extractor_name": "ex_extractor_name",
+    "extractor_version": "ex_extractor_version",
+    "extraction_parameter": {"parameter1": "pvalue1"},
+    "extraction_time": 1111666.3333,
+    "agent_name": "test_name",
+    "agent_email": "test email",
+    "dataset_id": "00010203-1011-2021-3031-404142434445",
+    "dataset_version": "000000111111111112012121212121",
+    "extracted_metadata": {"info": "some metadata"}
+}
+
+
+additional_keys_template = {
+    "root_dataset_id": "aa010203-1011-2021-3031-404142434445",
+    "root_dataset_version": "aaaaaaa0000000000000000222222222",
+    "inter_dataset_path": "sub_0/sub_0.0/dataset_0.0.0"
+}
+
+
+def _assert_raise_mke_with_keys(exception_keys: List[str],
+                                *args,
+                                **kwargs):
+
+    try:
+        meta_add(*args, **kwargs)
+        raise RuntimeError("MetadataKeyException not raised")
+    except MetadataKeyException as mke:
+        eq_(mke.keys, exception_keys)
+
+
+@with_tempfile
+def test_unknown_key_reporting(file_name):
+
+    json.dump({
+            **metadata_template,
+            "strange_key_name": "some value"
+        },
+        open(file_name, "tw"))
+
+    _assert_raise_mke_with_keys(
+        ["strange_key_name"],
+        metadata=file_name)
+
+
+@with_tempfile
+def test_unknown_key_allowed(file_name):
+
+    json.dump({
+            **metadata_template,
+            "strange_key_name": "some value"
+        },
+        open(file_name, "tw"))
+
+    with \
+            patch("datalad_metalad.add.add_file_metadata") as fp, \
+            patch("datalad_metalad.add.add_dataset_metadata") as dp:
+
+        meta_add(
+            metadata=file_name,
+            allow_unknown=True)
+
+        assert_true(fp.call_count == 0)
+        assert_true(dp.call_count == 1)
+
+
+@with_tempfile
+def test_optional_keys(file_name):
+
+    json.dump({
+            **metadata_template,
+            "intra_dataset_path": "d1/d1.1./f1.1.1"
+        },
+        open(file_name, "tw"))
+
+    with \
+            patch("datalad_metalad.add.add_file_metadata") as fp, \
+            patch("datalad_metalad.add.add_dataset_metadata") as dp:
+
+        meta_add(
+            metadata=file_name,
+            allow_unknown=True)
+
+        assert_true(fp.call_count == 1)
+        assert_true(dp.call_count == 0)
+
+
+@with_tempfile
+def test_incomplete_non_mandatory_key_handling(file_name):
+    json.dump(metadata_template, open(file_name, "tw"))
+    _assert_raise_mke_with_keys(
+        ["root_dataset_version", "inter_dataset_path"],
+        metadata=file_name,
+        additionalvalues=json.dumps({"root_dataset_id": 1}))
+
+
+@with_tempfile
+def test_override_key_reporting(file_name):
+    json.dump(metadata_template, open(file_name, "tw"))
+    _assert_raise_mke_with_keys(
+        ["dataset_id"],
+        metadata=file_name,
+        additionalvalues=json.dumps(
+            {"dataset_id": "a2010203-1011-2021-3031-404142434445"}))
+
+
+@with_tempfile
+def test_override_key_allowed(file_name):
+    json.dump(metadata_template, open(file_name, "tw"))
+
+    with \
+            patch("datalad_metalad.add.add_file_metadata") as fp, \
+            patch("datalad_metalad.add.add_dataset_metadata") as dp:
+
+        meta_add(
+            metadata=file_name,
+            additionalvalues=json.dumps(
+                {"dataset_id": "a1010203-1011-2021-3031-404142434445"}),
+            allow_override=True)
+
+        assert_true(fp.call_count == 0)
+        assert_true(dp.call_count == 1)
+
+
+def _get_top_nodes(git_repo, dataset_id, dataset_version):
+    # Ensure that metadata was created
+    tree_version_list, uuid_set, mrr = \
+        get_top_nodes_and_metadata_root_record(
+            "git",
+            git_repo.path,
+            dataset_id,
+            dataset_version,
+            MetadataPath(""))
+
+    assert_is_not_none(tree_version_list)
+    assert_is_not_none(uuid_set)
+    assert_is_not_none(mrr)
+
+    return tree_version_list, uuid_set, mrr
+
+
+def _get_metadata_content(metadata):
+
+    assert_is_not_none(metadata)
+    metadata_instances = tuple(metadata.extractor_runs())
+    assert_true(len(metadata_instances) == 1)
+
+    extractor_name, extractor_runs = metadata_instances[0]
+    eq_(extractor_name, metadata_template["extractor_name"])
+
+    instances = tuple(extractor_runs.get_instances())
+    assert_true(len(instances), 1)
+
+    return instances[0].metadata_source.content
+
+
+@with_tempfile
+def test_add_dataset_end_to_end(file_name):
+    json.dump(metadata_template, open(file_name, "tw"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+
+        git_repo = GitRepo(temp_dir)
+
+        res = meta_add(metadata=file_name, metadata_store=git_repo.path)
+        assert_result_count(res, 1)
+        assert_result_count(res, 1, type='dataset')
+        assert_result_count(res, 0, type='file')
+
+        # Verify dataset level metadata was added
+        tree_version_list, uuid_set, mrr = _get_top_nodes(
+            git_repo,
+            UUID(metadata_template["dataset_id"]),
+            metadata_template["dataset_version"])
+
+        metadata = mrr.get_dataset_level_metadata()
+        metadata_content = _get_metadata_content(metadata)
+        eq_(metadata_content, metadata_template["extracted_metadata"])
+
+
+@with_tempfile
+def test_add_file_end_to_end(file_name):
+
+    test_path = "d_0/d_0.0/f_0.0.0"
+
+    json.dump({
+        **metadata_template,
+        "intra_dataset_path": test_path
+    }, open(file_name, "tw"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = GitRepo(temp_dir)
+
+        res = meta_add(metadata=file_name, metadata_store=git_repo.path)
+        assert_result_count(res, 1)
+        assert_result_count(res, 1, type='file')
+        assert_result_count(res, 0, type='dataset')
+
+        # Verify file level metadata was added
+        tree_version_list, uuid_set, mrr = _get_top_nodes(
+            git_repo,
+            UUID(metadata_template["dataset_id"]),
+            metadata_template["dataset_version"])
+
+        file_tree = mrr.get_file_tree()
+        assert_is_not_none(file_tree)
+        assert_true(test_path in file_tree)
+
+        metadata = file_tree.get_metadata(MetadataPath(test_path))
+        metadata_content = _get_metadata_content(metadata)
+        eq_(metadata_content, metadata_template["extracted_metadata"])
+
+
+@with_tempfile
+def test_subdataset_add_dataset_end_to_end(file_name):
+
+    json.dump({
+        **metadata_template,
+        **additional_keys_template
+    }, open(file_name, "tw"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = GitRepo(temp_dir)
+
+        res = meta_add(metadata=file_name, metadata_store=git_repo.path)
+        assert_result_count(res, 1)
+        assert_result_count(res, 1, type='dataset')
+        assert_result_count(res, 0, type='file')
+
+        # Verify dataset level metadata was added
+        root_dataset_id = UUID(additional_keys_template["root_dataset_id"])
+        root_dataset_version = additional_keys_template["root_dataset_version"]
+        dataset_tree_path = MetadataPath(
+            additional_keys_template["inter_dataset_path"])
+
+        tree_version_list, uuid_set, mrr = _get_top_nodes(
+            git_repo,
+            root_dataset_id,
+            root_dataset_version)
+
+        _, dataset_tree = tree_version_list.get_dataset_tree(
+            root_dataset_version)
+
+        mrr = dataset_tree.get_metadata_root_record(dataset_tree_path)
+        eq_(mrr.dataset_identifier, UUID(metadata_template["dataset_id"]))
+
+        metadata = mrr.get_dataset_level_metadata()
+        metadata_content = _get_metadata_content(metadata)
+        eq_(metadata_content, metadata_template["extracted_metadata"])
+
+
+@with_tempfile
+def test_subdataset_add_file_end_to_end(file_name):
+
+    test_path = "d_1/d_1.0/f_1.0.0"
+
+    json.dump({
+        **metadata_template,
+        **additional_keys_template,
+        "intra_dataset_path": test_path
+    }, open(file_name, "tw"))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = GitRepo(temp_dir)
+
+        res = meta_add(metadata=file_name, metadata_store=git_repo.path)
+        assert_result_count(res, 1)
+        assert_result_count(res, 1, type='file')
+        assert_result_count(res, 0, type='dataset')
+
+        # Verify dataset level metadata was added
+        root_dataset_id = UUID(additional_keys_template["root_dataset_id"])
+        root_dataset_version = additional_keys_template["root_dataset_version"]
+        dataset_tree_path = MetadataPath(
+            additional_keys_template["inter_dataset_path"])
+
+        tree_version_list, uuid_set, mrr = _get_top_nodes(
+            git_repo,
+            root_dataset_id,
+            root_dataset_version)
+
+        _, dataset_tree = tree_version_list.get_dataset_tree(
+            root_dataset_version)
+
+        mrr = dataset_tree.get_metadata_root_record(dataset_tree_path)
+        eq_(mrr.dataset_identifier, UUID(metadata_template["dataset_id"]))
+
+        file_tree = mrr.get_file_tree()
+        assert_is_not_none(file_tree)
+        assert_true(test_path in file_tree)
+
+        metadata = file_tree.get_metadata(MetadataPath(test_path))
+        metadata_content = _get_metadata_content(metadata)
+        eq_(metadata_content, metadata_template["extracted_metadata"])

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -21,6 +21,7 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_true,
     eq_,
+    skip_if_on_windows,
     with_tempfile
 )
 
@@ -186,6 +187,7 @@ def _get_metadata_content(metadata):
     return instances[0].metadata_source.content
 
 
+@skip_if_on_windows
 @with_tempfile
 def test_add_dataset_end_to_end(file_name):
     json.dump(metadata_template, open(file_name, "tw"))
@@ -210,6 +212,7 @@ def test_add_dataset_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
+@skip_if_on_windows
 @with_tempfile
 def test_add_file_end_to_end(file_name):
 
@@ -243,6 +246,7 @@ def test_add_file_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
+@skip_if_on_windows
 @with_tempfile
 def test_subdataset_add_dataset_end_to_end(file_name):
 
@@ -281,6 +285,7 @@ def test_subdataset_add_dataset_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
+@skip_if_on_windows
 @with_tempfile
 def test_subdataset_add_file_end_to_end(file_name):
 

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -184,7 +184,7 @@ def _get_metadata_content(metadata):
     instances = tuple(extractor_runs.get_instances())
     assert_true(len(instances), 1)
 
-    return instances[0].metadata_source.content
+    return instances[0].metadata_content
 
 
 @skip_if_on_windows

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -137,6 +137,36 @@ def test_override_key_reporting(file_name):
             {"dataset_id": "a2010203-1011-2021-3031-404142434445"}))
 
 
+def test_object_parameter():
+    with \
+            patch("datalad_metalad.add.add_file_metadata") as fp, \
+            patch("datalad_metalad.add.add_dataset_metadata") as dp:
+
+        meta_add(
+            metadata={
+                **metadata_template,
+                "intra_dataset_path": "d1/d1.1./f1.1.1"
+            })
+
+        assert_true(fp.call_count == 1)
+        assert_true(dp.call_count == 0)
+
+
+def test_additional_values_object_parameter():
+    with \
+            patch("datalad_metalad.add.add_file_metadata") as fp, \
+            patch("datalad_metalad.add.add_dataset_metadata") as dp:
+
+        meta_add(
+            metadata=metadata_template,
+            additionalvalues={
+                "intra_dataset_path": "d1/d1.1./f1.1.1"
+            })
+
+        assert_true(fp.call_count == 1)
+        assert_true(dp.call_count == 0)
+
+
 @with_tempfile
 def test_override_key_allowed(file_name):
     json.dump(metadata_template, open(file_name, "tw"))

--- a/datalad_metalad/tests/test_base.py
+++ b/datalad_metalad/tests/test_base.py
@@ -11,15 +11,9 @@
 
 from six import text_type
 import os
-import os.path as op
 
 from datalad.distribution.dataset import Dataset
 from datalad.support.gitrepo import GitRepo
-from datalad.api import (
-    create,
-    save,
-    remove,
-)
 from .. import (
     get_metadata_type,
     get_refcommit,
@@ -29,7 +23,7 @@ from datalad.tests.utils import (
     eq_,
     create_tree,
     assert_repo_status,
-    skip_if_on_windows,
+    known_failure
 )
 
 
@@ -56,7 +50,7 @@ def test_get_metadata_type_oldcfg(path):
     eq_(get_metadata_type(ds), 'mamboschwambo')
 
 
-@skip_if_on_windows
+@known_failure
 @with_tempfile(mkdir=True)
 def test_get_refcommit(path):
     # # dataset without a single commit

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -99,17 +99,17 @@ def test_dataset_extraction_end_to_end(path):
 
     instances = tuple(extractor_runs.get_instances())
     assert_true(len(instances), 1)
-    immediate_metadata = instances[0].metadata_source.content
+    metadata_content = instances[0].metadata_content
     
-    assert_in("id", immediate_metadata)
-    assert_in("refcommit", immediate_metadata)
-    assert_in("path", immediate_metadata)
-    assert_in("comment", immediate_metadata)
+    assert_in("id", metadata_content)
+    assert_in("refcommit", metadata_content)
+    assert_in("path", metadata_content)
+    assert_in("comment", metadata_content)
 
-    eq_(immediate_metadata["id"], ds.id)
-    eq_(immediate_metadata["refcommit"], ds.repo.get_hexsha())
-    eq_(immediate_metadata["path"], ds.path)
-    eq_(immediate_metadata["comment"], "test-implementation")
+    eq_(metadata_content["id"], ds.id)
+    eq_(metadata_content["refcommit"], ds.repo.get_hexsha())
+    eq_(metadata_content["path"], ds.path)
+    eq_(metadata_content["comment"], "test-implementation")
 
 
 @with_tree(meta_tree)
@@ -158,17 +158,17 @@ def test_file_extraction_end_to_end(path):
 
     instances = tuple(extractor_runs.get_instances())
     assert_true(len(instances), 1)
-    immediate_metadata = instances[0].metadata_source.content
+    metadata_content = instances[0].metadata_content
 
-    assert_in("@id", immediate_metadata)
-    assert_in("path", immediate_metadata)
-    assert_in("intra_dataset_path", immediate_metadata)
-    assert_in("content_byte_size", immediate_metadata)
-    assert_in("comment", immediate_metadata)
+    assert_in("@id", metadata_content)
+    assert_in("path", metadata_content)
+    assert_in("intra_dataset_path", metadata_content)
+    assert_in("content_byte_size", metadata_content)
+    assert_in("comment", metadata_content)
 
-    eq_(immediate_metadata["path"], str(ds.pathobj / "sub" / "one"))
+    eq_(metadata_content["path"], str(ds.pathobj / "sub" / "one"))
     eq_(
-        MetadataPath(immediate_metadata["intra_dataset_path"]),
+        MetadataPath(metadata_content["intra_dataset_path"]),
         MetadataPath("sub/one"))
 
-    eq_(immediate_metadata["comment"], "test-implementation")
+    eq_(metadata_content["comment"], "test-implementation")

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,4 +11,4 @@ pyyaml
 # Remove click and dataclasses once the metadata model distribution is on pypi
 click
 dataclasses
-git+https://github.com/christian-monch/metadata-model.git@alpha9#egg=datalad-metadata-model
+git+https://github.com/christian-monch/metadata-model.git@alpha10#egg=datalad-metadata-model

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -11,4 +11,4 @@ pyyaml
 # Remove click and dataclasses once the metadata model distribution is on pypi
 click
 dataclasses
-git+https://github.com/christian-monch/metadata-model.git@alpha10#egg=datalad-metadata-model
+git+https://github.com/christian-monch/metadata-model.git@alpha11#egg=datalad-metadata-model


### PR DESCRIPTION
This fixes #93, which in turn addresses the separation from metadata extraction and metadata storage in a metadata model instance.

This PR introduces a new metalad commando: meta-add. It is used to add metadata that was extracted by an extractor, or created by other means. The internal structure of the metadata is (will be) shared between: meta-extract, meta-add, and meta-dump.

This PR is a pre-condition to remove automated storage of metadata from meta-extract.