### PR TITLE
NF Fix output of dump

### DIFF
--- a/datalad_metalad/dump.py
+++ b/datalad_metalad/dump.py
@@ -179,8 +179,8 @@ def _create_result_record(mapper: str,
 def _create_metadata_instance_record(instance: MetadataInstance) -> dict:
     return {
         "extraction_time": instance.time_stamp,
-        "extraction_agent_name": f"{instance.author_name}",
-        "extraction_agent_email": f"<{instance.author_email}>",
+        "extraction_agent_name": instance.author_name,
+        "extraction_agent_email": instance.author_email,
         "extractor_version": instance.configuration.version,
         "extraction_parameter": instance.configuration.parameter,
         "extraction_result": instance.metadata_content
@@ -443,47 +443,44 @@ class Dump(Interface):
         UUID:   "uuid:" UUID-DIGITS ["@" VERSION-DIGITS] [":" [LOCAL_PATH]]
 
     (the tree-format is the default format and does not require a prefix).
-
-    The elements DATASET_PATH and LOCAL_PATH take wild-card patterns. So you can
-    find all JSON files in the root directory of all datasets by specifying:
-
-        \\*:\\*.json
-
-    as DATASET_FILE_PATH_PATTERN and specifying recursive in order to
-    go through metadata for all datasets, e.g.:
-
-      % datalad -f json_pp meta-dump \\*:\\*.json -r --reporton files
-
-    or simply do not specify a specific dataset at all:
-
-      % datalad -f json_pp meta-dump :\\*.json -r --reporton files
-
-    Examples:
-
-      Dump the metadata of the file "dataset_description.json" in the
-      dataset "simon". (The queried dataset git-repository is determined
-      based on the current working directory)::
-
-        % datalad meta-dump --reporton files simon:dataset_description.json
-
-      Sometimes it is helpful to get metadata records formatted in a more
-      accessible form, here as pretty-printed JSON::
-
-        % datalad -f json_pp meta-dump simon:dataset_description.json
-
-      Same query as above, but specify that all datasets should be queried
-      for the given path::
-
-        % datalad meta-dump -d . :somedir/subdir/thisfile.dat
-
-      Dump any metadata record of any dataset known to the queried dataset::
-
-        % datalad meta-dump -r --reporton datasets
-
     """
-    # make the custom renderer the default, path reporting isn't the top
-    # priority here
+
+    # Use a custom renderer to emit a self-contained metadata record. The
+    # emitted record can be fed into meta-add for example.
     result_renderer = 'tailored'
+
+    _examples_ = [
+        dict(
+            text='Dump the metadata of the file "dataset_description.json" in '
+                 'the dataset "simon". (The queried dataset git-repository is '
+                 'determined based on the current working directory)',
+            code_cmd="datalad meta-dump simon:dataset_description.json"),
+        dict(
+            text="Sometimes it is helpful to get metadata records formatted "
+                 "in a more accessible form, here as pretty-printed JSON",
+            code_cmd="datalad -f json_pp meta-dump "
+                     "simon:dataset_description.json"),
+        dict(
+            text="Same query as above, but specify that all datasets should "
+                 "be queried for the given path",
+            code_cmd="datalad meta-dump -d . :somedir/subdir/thisfile.dat"),
+        dict(
+            text="Dump any metadata record of any dataset known to the "
+                 "queried dataset",
+            code_cmd="datalad meta-dump -r"),
+        dict(
+            text="Show metadata for all datasets",
+            code_cmd="datalad -f json_pp meta-dump -r"),
+        dict(
+            text="Show metadata for all files ending in `.json´ in the root "
+                 "directories of all datasets",
+            code_cmd="datalad -f json_pp meta-dump *:*.json -r"),
+        dict(
+            text="Show metadata for all files ending in `.json´ in all "
+                 "datasets by not specifying a dataset at all. This will "
+                 "start dumping at the top-level dataset.",
+            code_cmd="datalad -f json_pp meta-dump :*.json -r")
+    ]
 
     _params_ = dict(
         backend=Parameter(

--- a/datalad_metalad/extractors/core_dataset.py
+++ b/datalad_metalad/extractors/core_dataset.py
@@ -52,5 +52,5 @@ class DataladCoreDatasetExtractor(DatasetMetadataExtractor):
                 "id": self.dataset.id,
                 "refcommit": self.dataset.repo.get_hexsha(),
                 "path": self.dataset.path,
-                "comment": "test-implementation"
+                "comment": "test-implementation of core_dataset"
             })

--- a/datalad_metalad/extractors/core_file.py
+++ b/datalad_metalad/extractors/core_file.py
@@ -55,8 +55,7 @@ class DataladCoreFileExtractor(FileMetadataExtractor):
                     path=self.file_info.path,
                     type=self.file_info.type)),
                 "type": self.file_info.type,
-                "path": self.file_info.path,
-                "intra_dataset_path": self.file_info.intra_dataset_path,
+                "path": self.file_info.intra_dataset_path,
                 "content_byte_size": self.file_info.byte_size,
-                "comment": "test-implementation"
+                "comment": "test-implementation of core_file"
             })

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -109,7 +109,7 @@ def test_dataset_extraction_end_to_end(path):
     eq_(metadata_content["id"], ds.id)
     eq_(metadata_content["refcommit"], ds.repo.get_hexsha())
     eq_(metadata_content["path"], ds.path)
-    eq_(metadata_content["comment"], "test-implementation")
+    eq_(metadata_content["comment"], "test-implementation of core_dataset")
 
 
 @with_tree(meta_tree)
@@ -161,14 +161,11 @@ def test_file_extraction_end_to_end(path):
     metadata_content = instances[0].metadata_content
 
     assert_in("@id", metadata_content)
+    assert_in("type", metadata_content)
     assert_in("path", metadata_content)
-    assert_in("intra_dataset_path", metadata_content)
     assert_in("content_byte_size", metadata_content)
     assert_in("comment", metadata_content)
 
-    eq_(metadata_content["path"], str(ds.pathobj / "sub" / "one"))
-    eq_(
-        MetadataPath(metadata_content["intra_dataset_path"]),
-        MetadataPath("sub/one"))
-
-    eq_(metadata_content["comment"], "test-implementation")
+    eq_(metadata_content["type"], "file")
+    eq_(metadata_content["path"], str("sub/one"))
+    eq_(metadata_content["comment"], "test-implementation of core_file")


### PR DESCRIPTION
This PR resolves issue #84 (and #82).

`meta-dump` will now output self-contained metadata-records that describe metadata associated with:

1. A dataset or dataset-element, i.e. file
2. An extractor name (although an extractor might not have been used to create the metadata, extractor_name still identifies the format/type of the metadata)
3. A set of parameters that were used during the "extraction" process.

Records are new-line separated JSON-strings

The resulting metadata records can be directly fed into `meta-add` (line by line for now, since `meta-add` does not support new-line separated input yet).