### PR TITLE
Remove metadata storage from meta extract

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -221,9 +221,25 @@ class Extract(Interface):
         if res["status"] != "ok" or res.get("action", "") != 'meta_extract':
             # logging complained about this already
             return
+
+        metadata_record = res["metadata_record"]
+        path = (
+            {"path": str(metadata_record["path"])}
+            if "path" in metadata_record
+            else {}
+        )
+
+        inter_dataset_path = (
+            {"inter_dataset_path": str(metadata_record["inter_dataset_path"])}
+            if "inter_dataset_path" in metadata_record
+            else {}
+        )
+
         ui.message(json.dumps({
-            **res["metadata_record"],
-            "dataset_id": str(res["metadata_record"]["dataset_id"])
+            **metadata_record,
+            **path,
+            **inter_dataset_path,
+            "dataset_id": str(metadata_record["dataset_id"])
         }))
 
 
@@ -299,7 +315,7 @@ def perform_file_metadata_extraction(ep: ExtractionParameter,
             type="file",
             dataset_id=ep.source_dataset_id,
             dataset_version=ep.source_dataset_version,
-            intra_dataset_path=ep.file_tree_path,
+            path=ep.file_tree_path,
             extractor_name=ep.extractor_name,
             extractor_version=extractor.get_version(),
             extraction_parameter=ep.extractor_arguments,
@@ -595,7 +611,7 @@ def legacy_extract_file(ep: ExtractionParameter) -> Iterable[dict]:
                     type="file",
                     dataset_id=ep.source_dataset_id,
                     dataset_version=ep.source_dataset_version,
-                    intra_dataset_path=ep.file_tree_path,
+                    path=ep.file_tree_path,
                     extractor_name=ep.extractor_name,
                     extractor_version=str(
                         extractor.get_state(ep.source_dataset)["version"]),
@@ -626,7 +642,7 @@ def legacy_extract_file(ep: ExtractionParameter) -> Iterable[dict]:
                     type="file",
                     dataset_id=ep.source_dataset_id,
                     dataset_version=ep.source_dataset_version,
-                    intra_dataset_path=MetadataPath(path),
+                    path=MetadataPath(path),
                     extractor_name=ep.extractor_name,
                     extractor_version="un-versioned",
                     extraction_parameter=ep.extractor_arguments,

--- a/datalad_metalad/extractors/core_dataset.py
+++ b/datalad_metalad/extractors/core_dataset.py
@@ -11,7 +11,6 @@ import logging
 from uuid import UUID
 
 from .base import DataOutputCategory, ExtractorResult, DatasetMetadataExtractor
-from datalad.log import log_progress
 
 
 lgr = logging.getLogger('datalad.metadata.extractors.metalad_core_dataset')
@@ -32,14 +31,6 @@ class DataladCoreDatasetExtractor(DatasetMetadataExtractor):
         return True
 
     def extract(self, _=None) -> ExtractorResult:
-        log_progress(
-            lgr.info,
-            "datalad_core_dataset_extractor",
-            "Running core dataset extraction for uuid:%s, tree:%s",
-            self.dataset.id,
-            self.dataset.path,
-            label="Core dataset metadata extraction")
-
         return ExtractorResult(
             extractor_version=self.get_version(),
             extraction_parameter=self.parameter or {},

--- a/datalad_metalad/extractors/core_dataset.py
+++ b/datalad_metalad/extractors/core_dataset.py
@@ -42,6 +42,6 @@ class DataladCoreDatasetExtractor(DatasetMetadataExtractor):
             immediate_data={
                 "id": self.dataset.id,
                 "refcommit": self.dataset.repo.get_hexsha(),
-                "path": self.dataset.path,
+                "inter_dataset_path": "",
                 "comment": "test-implementation of core_dataset"
             })

--- a/datalad_metalad/extractors/core_file.py
+++ b/datalad_metalad/extractors/core_file.py
@@ -12,7 +12,6 @@ from uuid import UUID
 
 from .. import get_file_id
 from .base import DataOutputCategory, ExtractorResult, FileMetadataExtractor
-from datalad.log import log_progress
 
 
 lgr = logging.getLogger('datalad.metadata.extractors.metalad_core_file')
@@ -33,15 +32,6 @@ class DataladCoreFileExtractor(FileMetadataExtractor):
         return "0.0.1"
 
     def extract(self, _=None) -> ExtractorResult:
-        log_progress(
-            lgr.info,
-            "datalad_core_file_extractor",
-            "Running core file extraction for %s in %s",
-            self.file_info.intra_dataset_path,
-            self.dataset.path,
-            label="Core file metadata extraction",
-            unit="File")
-
         return ExtractorResult(
             extractor_version=self.get_version(),
             extraction_parameter=self.parameter or {},

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -67,6 +67,7 @@ def test_unknown_key_reporting(file_name):
 
     json.dump({
             **metadata_template,
+            "type": "dataset",
             "strange_key_name": "some value"
         },
         open(file_name, "tw"))
@@ -81,6 +82,7 @@ def test_unknown_key_allowed(file_name):
 
     json.dump({
             **metadata_template,
+            "type": "dataset",
             "strange_key_name": "some value"
         },
         open(file_name, "tw"))
@@ -102,7 +104,8 @@ def test_optional_keys(file_name):
 
     json.dump({
             **metadata_template,
-            "intra_dataset_path": "d1/d1.1./f1.1.1"
+            "type": "file",
+            "path": "d1/d1.1./f1.1.1"
         },
         open(file_name, "tw"))
 
@@ -120,7 +123,12 @@ def test_optional_keys(file_name):
 
 @with_tempfile
 def test_incomplete_non_mandatory_key_handling(file_name):
-    json.dump(metadata_template, open(file_name, "tw"))
+    json.dump({
+            **metadata_template,
+            "type": "dataset"
+        },
+        open(file_name, "tw"))
+
     _assert_raise_mke_with_keys(
         ["root_dataset_version", "inter_dataset_path"],
         metadata=file_name,
@@ -129,7 +137,12 @@ def test_incomplete_non_mandatory_key_handling(file_name):
 
 @with_tempfile
 def test_override_key_reporting(file_name):
-    json.dump(metadata_template, open(file_name, "tw"))
+    json.dump({
+            **metadata_template,
+            "type": "dataset"
+        },
+        open(file_name, "tw"))
+
     _assert_raise_mke_with_keys(
         ["dataset_id"],
         metadata=file_name,
@@ -145,7 +158,8 @@ def test_object_parameter():
         meta_add(
             metadata={
                 **metadata_template,
-                "intra_dataset_path": "d1/d1.1./f1.1.1"
+                "type": "file",
+                "path": "d1/d1.1./f1.1.1"
             })
 
         assert_true(fp.call_count == 1)
@@ -158,9 +172,12 @@ def test_additional_values_object_parameter():
             patch("datalad_metalad.add.add_dataset_metadata") as dp:
 
         meta_add(
-            metadata=metadata_template,
+            metadata={
+                **metadata_template,
+                "type": "file"
+            },
             additionalvalues={
-                "intra_dataset_path": "d1/d1.1./f1.1.1"
+                "path": "d1/d1.1./f1.1.1"
             })
 
         assert_true(fp.call_count == 1)
@@ -169,7 +186,11 @@ def test_additional_values_object_parameter():
 
 @with_tempfile
 def test_override_key_allowed(file_name):
-    json.dump(metadata_template, open(file_name, "tw"))
+    json.dump({
+            **metadata_template,
+            "type": "dataset"
+        },
+        open(file_name, "tw"))
 
     with \
             patch("datalad_metalad.add.add_file_metadata") as fp, \
@@ -220,7 +241,11 @@ def _get_metadata_content(metadata):
 @skip_if_on_windows
 @with_tempfile
 def test_add_dataset_end_to_end(file_name):
-    json.dump(metadata_template, open(file_name, "tw"))
+    json.dump({
+            **metadata_template,
+            "type": "dataset"
+        },
+        open(file_name, "tw"))
 
     with tempfile.TemporaryDirectory() as temp_dir:
 
@@ -250,7 +275,8 @@ def test_add_file_end_to_end(file_name):
 
     json.dump({
         **metadata_template,
-        "intra_dataset_path": test_path
+        "type": "file",
+        "path": test_path
     }, open(file_name, "tw"))
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -281,9 +307,11 @@ def test_add_file_end_to_end(file_name):
 def test_subdataset_add_dataset_end_to_end(file_name):
 
     json.dump({
-        **metadata_template,
-        **additional_keys_template
-    }, open(file_name, "tw"))
+            **metadata_template,
+            "type": "dataset",
+            **additional_keys_template
+        },
+        open(file_name, "tw"))
 
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = GitRepo(temp_dir)
@@ -324,7 +352,8 @@ def test_subdataset_add_file_end_to_end(file_name):
     json.dump({
         **metadata_template,
         **additional_keys_template,
-        "intra_dataset_path": test_path
+        "type": "file",
+        "path": test_path
     }, open(file_name, "tw"))
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -73,7 +73,7 @@ def _check_metadata_record(metadata_record: dict,
     eq_(metadata_record["agent_name"], "DataLad Tester")
     eq_(metadata_record["agent_email"], "test@example.com")
     if path is not None:
-        eq_(metadata_record["intra_dataset_path"], MetadataPath(path))
+        eq_(metadata_record["path"], MetadataPath(path))
 
 
 @with_tree(meta_tree)
@@ -110,8 +110,8 @@ def test_dataset_extraction_result(path):
     extracted_metadata = metadata_record["extracted_metadata"]
     eq_(extracted_metadata["id"], ds.id)
     eq_(extracted_metadata["refcommit"], ds.repo.get_hexsha())
-    eq_(extracted_metadata["path"], ds.path)
-    eq_(extracted_metadata["comment"], "test-implementation")
+    eq_(extracted_metadata["inter_dataset_path"], "")
+    eq_(extracted_metadata["comment"], "test-implementation of core_dataset")
 
 
 @with_tree(meta_tree)
@@ -151,10 +151,9 @@ def test_file_extraction_result(ds_path):
     extracted_metadata = metadata_record["extracted_metadata"]
     assert_in("@id", extracted_metadata)
     eq_(extracted_metadata["type"], "file")
-    eq_(extracted_metadata["path"], str(ds.pathobj / file_path))
-    eq_(extracted_metadata["intra_dataset_path"], file_path)
+    eq_(extracted_metadata["path"], file_path)
     eq_(extracted_metadata["content_byte_size"], 111)
-    eq_(extracted_metadata["comment"], "test-implementation")
+    eq_(extracted_metadata["comment"], "test-implementation of core_file")
 
 
 @known_failure

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -149,10 +149,10 @@ def test_file_extraction_result(ds_path):
         path=file_path)
 
     extracted_metadata = metadata_record["extracted_metadata"]
+    assert_in("content_byte_size", extracted_metadata)
     assert_in("@id", extracted_metadata)
     eq_(extracted_metadata["type"], "file")
     eq_(extracted_metadata["path"], file_path)
-    eq_(extracted_metadata["content_byte_size"], 111)
     eq_(extracted_metadata["comment"], "test-implementation of core_file")
 
 


### PR DESCRIPTION
This PR addresses issue #79 and obsoletes issue #78

`meta-extract` will not store metadata any longer, but report it to the output channels as JSON-string.

`meta-add` can be used to save the metadata  in a metadata model instance, and consequently in a metadata store