### PR TITLE
Meta extract consolidation

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -210,6 +210,7 @@ class Extract(Interface):
         # If path is not given, we assume that a dataset-level extraction is
         # requested and the extractor class is a subclass of
         # DatasetMetadataExtractor (or a legacy extractor class).
+        # TODO: check whether paths are datasets.
         if path and path != "++":
             yield from do_file_extraction(extraction_parameters)
         else:
@@ -521,12 +522,17 @@ def legacy_extract_dataset(ep: ExtractionParameter) -> Iterable[dict]:
     if issubclass(ep.extractor_class, MetadataExtractor):
 
         # Metalad legacy extractor
-        status = [{
-            "type": "dataset",
-            "path": str(ep.source_dataset.pathobj),
-            "state": "clean",
-            "gitshasum": ep.source_dataset_version
-        }]
+        if False:
+            # TODO: fix this. Detect whether a path is a dataset
+            # and act appropriately.
+            status = [{
+                "type": "dataset",
+                "path": str(ep.source_dataset.pathobj),
+                "state": "clean",
+                "gitshasum": ep.source_dataset_version
+            }]
+        else:
+            status = []
         extractor = ep.extractor_class()
         ensure_legacy_content_availability(ep, extractor, "dataset", status)
 

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -20,6 +20,7 @@ from uuid import UUID
 
 from dataclasses import dataclass
 
+from datalad.coreapi import subdatasets
 from datalad.distribution.dataset import Dataset
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
@@ -84,14 +85,26 @@ class Extract(Interface):
     executes it on the dataset that is given by the current working
     directory or by the "-d" argument.
 
-    If a path is given, the command assumes that the given extractor is
-    a file-level extractor and executes it on the file that is given as
-    path parameter. If the file level extractor requests the content of
-    a file that is not present, the command might "get" the file content
-    to make it locally available.
+    If a path is given, the command assumes that the path identifies a
+    file and that the given extractor is a file-level extractor, which
+    will then be executed on the specified file. If the file level
+    extractor requests the content of a file that is not present, the
+    command might "get" the file content to make it locally available.
+    Path must not refer to a sub-dataset. Path must not be a directory.
 
-    [NOT IMPLEMENTED YET] The extractor configuration can be
-    parameterized with key-value pairs given as additional arguments.
+    .. note::
+    If you want to insert sub-dataset-metadata into the super-dataset's
+    metadata, you currently have to do the following:
+    first, extract dataset metadata of the sub-dataset using a dataset-
+    level extractor, second add the extracted metadata with sub-dataset
+    information (i.e. inter_dataset_path, root_dataset_id, root-dataset-
+    version) to the metadata of the super-dataset.
+
+    The extractor configuration can be parameterized with key-value pairs
+    given as additional arguments. Each key-value pair consists of two
+    arguments, first the key, followed by the value. If no path is given,
+    and you want to provide key-value pairs, you have to give the path
+    "++", to prevent that the first key is interpreted as path.
 
     The results are written into the repository of the source dataset
     or into the repository of the dataset given by the "-i" parameter.
@@ -176,6 +189,7 @@ class Extract(Interface):
         # Get basic arguments
         extractor_name = extractorname
         extractor_args = extractorargs
+        path = None if path == "++" else path
 
         source_dataset = require_dataset(
             dataset or curdir,
@@ -210,8 +224,11 @@ class Extract(Interface):
         # If path is not given, we assume that a dataset-level extraction is
         # requested and the extractor class is a subclass of
         # DatasetMetadataExtractor (or a legacy extractor class).
-        # TODO: check whether paths are datasets.
-        if path and path != "++":
+        path = None if path == "++" else path
+
+        if path:
+            # Check whether the path points to a sub_dataset.
+            ensure_path_validity(source_dataset, file_tree_path)
             yield from do_file_extraction(extraction_parameters)
         else:
             yield from do_dataset_extraction(extraction_parameters)
@@ -465,6 +482,16 @@ def get_path_info(dataset: Dataset,
     return dataset_tree_path, MetadataPath(file_tree_path)
 
 
+def ensure_path_validity(dataset: Dataset, file_tree_path: MetadataPath):
+    # TODO: there is most likely a better way to do this in datalad,
+    # but I want to ensure, that we do not enumerate all sub-datasets
+    # in order to perform this check on a known path.
+
+    full_path = dataset.pathobj / file_tree_path
+    if full_path.is_dir():
+        raise ValueError("FILE must not point to a directory")
+
+
 def ensure_content_availability(extractor: FileMetadataExtractor,
                                 file_info: FileInfo):
 
@@ -521,18 +548,7 @@ def legacy_extract_dataset(ep: ExtractionParameter) -> Iterable[dict]:
 
     if issubclass(ep.extractor_class, MetadataExtractor):
 
-        # Metalad legacy extractor
-        if False:
-            # TODO: fix this. Detect whether a path is a dataset
-            # and act appropriately.
-            status = [{
-                "type": "dataset",
-                "path": str(ep.source_dataset.pathobj),
-                "state": "clean",
-                "gitshasum": ep.source_dataset_version
-            }]
-        else:
-            status = []
+        status = []
         extractor = ep.extractor_class()
         ensure_legacy_content_availability(ep, extractor, "dataset", status)
 

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -93,12 +93,13 @@ class Extract(Interface):
     Path must not refer to a sub-dataset. Path must not be a directory.
 
     .. note::
-    If you want to insert sub-dataset-metadata into the super-dataset's
-    metadata, you currently have to do the following:
-    first, extract dataset metadata of the sub-dataset using a dataset-
-    level extractor, second add the extracted metadata with sub-dataset
-    information (i.e. inter_dataset_path, root_dataset_id, root-dataset-
-    version) to the metadata of the super-dataset.
+
+        If you want to insert sub-dataset-metadata into the super-dataset's
+        metadata, you currently have to do the following:
+        first, extract dataset metadata of the sub-dataset using a dataset-
+        level extractor, second add the extracted metadata with sub-dataset
+        information (i.e. inter_dataset_path, root_dataset_id, root-dataset-
+        version) to the metadata of the super-dataset.
 
     The extractor configuration can be parameterized with key-value pairs
     given as additional arguments. Each key-value pair consists of two

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -156,7 +156,6 @@ def test_file_extraction_result(ds_path):
     eq_(extracted_metadata["comment"], "test-implementation of core_file")
 
 
-@known_failure
 @with_tree(meta_tree)
 def test_legacy1_dataset_extraction_result(ds_path):
 
@@ -188,7 +187,8 @@ def test_legacy1_dataset_extraction_result(ds_path):
         extraction_parameter={})
 
     extracted_metadata = metadata_record["extracted_metadata"]
-    assert_in("@id", extracted_metadata)
+    assert_in("@context", extracted_metadata)
+    assert_in("@graph", extracted_metadata)
     eq_(extracted_metadata["contentbytesize"], 1)
 
 

--- a/tools/extract_core_metadata.py
+++ b/tools/extract_core_metadata.py
@@ -29,7 +29,7 @@ running_processes: List[subprocess.Popen] = list()
 logger = logging.getLogger("extract_core_metadata")
 
 argument_parser = ArgumentParser(
-    description="Parallel recursive metadata extraction")
+    description="Parallel recursive metadata extraction and storage")
 
 argument_parser.add_argument(
     "-m", "--max-processes",
@@ -90,14 +90,15 @@ def execute_command_line(purpose, command_line):
         f"started process {p.pid} [{purpose}]: {' '.join(command_line)}")
 
 
-def extract_dataset_level_metadata(realm: str,
+def extract_dataset_level_metadata(metadata_store: str,
                                    dataset_path: str,
                                    metalad_arguments: List[str]):
 
     purpose = f"extract_dataset: {dataset_path}"
     command_line = [
         "datalad", "-l", arguments.log_level, "meta-extract",
-        f"{arguments.dataset_extractor}", "-d", dataset_path, "-i", realm
+        f"{arguments.dataset_extractor}", "-d", dataset_path,
+        "-i", metadata_store
     ] + metalad_arguments
     execute_command_line(purpose, command_line)
 


### PR DESCRIPTION
This PR streamlines the behavior of meta-extract w.r.t. the approach that either a file or a dataset is extracted in a single invocation of meta-extract.

Meta-extract will not try to extract directories any longer. That means it will also not extract a sub-dataset as part of a file-level extraction. (There is a loss of information that we have to discuss, i.e. the hasPart-, and isPartOf-elements of the JSON-LD description. This could be added by filters for example).

To extract sub-datasets, perform a dataset-level extraction on them and either add them to a super-dataset metadata store with the appropriate additional keys (inter_dataset_path, root_dataset_id, root_dataset_version) or aggregate the metadata into the super dataset.

This PR also fixes the description: extraction parameters are supported.

