### PR TITLE
Improve meta-dump error reporting

### DIFF
--- a/datalad_metalad/exceptions.py
+++ b/datalad_metalad/exceptions.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.utils import ensure_unicode
 
 
@@ -22,3 +23,7 @@ class MetadataKeyException(RuntimeError):
 
     def __str__(self):
         return self.to_str()
+
+
+class NoMetadataStoreFound(InsufficientArgumentsError):
+    pass


### PR DESCRIPTION
This fixes issue #78 and parts of issue #103

Meta-dump will report on invalid metadata and, by using the updated metadata model, report old metadata versions, that cannot be processed any longer
