### PR TITLE
Use datasets instead of metadata stores in UI

### DIFF
--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -128,7 +128,7 @@ class Add(Interface):
                  'metadata model instance in the current directory and '
                  'overwrite metadata values with the values stored in '
                  '"extra-info.json"',
-            code_cmd='atalad meta-add --metadata-store /home/user/dataset_0 '
+            code_cmd='datalad meta-add --metadata-store /home/user/dataset_0 '
                      'metadata-123.json @extra-info.json'
         )
     ]

--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -209,25 +209,25 @@ class Add(Interface):
             directory.""",
             constraints=EnsureDataset() | EnsureNone()),
         allow_override=Parameter(
-            args=("-o", "--allow-override"),
+            args=("-o", "--allow-override",),
+            action='store_true',
             doc="""Allow the additional values to override values given in
             metadata.""",
-            default=False,
-            constraints=EnsureBool() | EnsureNone()),
+            default=False),
         allow_unknown=Parameter(
-            args=("-u", "--allow-unknown"),
+            args=("-u", "--allow-unknown",),
+            action='store_true',
             doc="""Allow unknown keys. By default, unknown keys generate
             an errors. If this switch is True, unknown keys will only be
             reported. For processing unknown keys will be ignored.""",
-            default=False,
-            constraints=EnsureBool() | EnsureNone()),
+            default=False),
         allow_id_mismatch=Parameter(
-            args=("-m", "--allow-id-mismatch"),
+            args=("-i", "--allow-id-mismatch",),
+            action='store_true',
             doc="""Allow insertion of metadata, even if the "dataset-id" in
             the metadata source does not match the ID of the target
             dataset.""",
-            default=False,
-            constraints=EnsureBool() | EnsureNone()))
+            default=False))
 
     @staticmethod
     @datasetmethod(name="meta_add")
@@ -256,8 +256,9 @@ class Add(Interface):
 
         add_parameter = AddParameter(
             result_path=(
-                Path(metadata.get("dataset_path", "."))
-                / Path(metadata.get("path", ""))),
+                dataset.pathobj
+                / Path(metadata.get("dataset_path", "."))
+                / Path(metadata.get("path", ""))).resolve(),
             dataset_id=UUID(metadata["dataset_id"]),
             dataset_version=metadata["dataset_version"],
             file_path=(
@@ -405,16 +406,18 @@ def check_dataset_ids(dataset, add_parameter: AddParameter) -> Optional[dict]:
                 action="meta-add",
                 status="error",
                 path=add_parameter.result_path,
-                message='provided "root-dataset-id" does not match ID of '
-                        'dataset {dataset.path}')
+                message=f'value of "root-dataset-id" '
+                        f'({add_parameter.root_dataset_id}) does not match '
+                        f'ID of dataset at {dataset.path} ({dataset.id})')
     else:
         if add_parameter.dataset_id != UUID(dataset.id):
             return dict(
                 action="meta-add",
                 status="error",
                 path=add_parameter.result_path,
-                message='provided "dataset-id" does not match ID of '
-                        'dataset {dataset.path}')
+                message=f'value of "dataset-id" '
+                        f'({add_parameter.dataset_id}) does not match '
+                        f'ID of dataset at {dataset.path} ({dataset.id})')
 
 
 def _get_top_nodes(realm: str, ap: AddParameter):

--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -22,11 +22,10 @@ from uuid import UUID
 
 from dataclasses import dataclass
 
+from datalad.distribution.dataset import Dataset, EnsureDataset, datasetmethod
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.interface.utils import eval_results
-from datalad.distribution.dataset import datasetmethod
-
 from datalad.support.constraints import EnsureBool
 from datalad.support.constraints import (
     EnsureNone,
@@ -46,6 +45,7 @@ from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
 
 from .exceptions import MetadataKeyException
+from .utils import check_dataset
 
 
 JSONObject = Union[Dict, List]
@@ -60,6 +60,8 @@ lgr = logging.getLogger("datalad.metadata.add")
 
 @dataclass
 class AddParameter:
+    result_path: Path
+
     dataset_id: UUID
     dataset_version: str
     file_path: MetadataPath
@@ -80,12 +82,16 @@ class AddParameter:
 
 @build_doc
 class Add(Interface):
-    r"""Add metadata to metadata model instance.
+    r"""Add metadata to a dataset.
 
     This command reads metadata from a source and adds this metadata
-    to a metadata model instance. A source can be: arguments, standard
-    input, or a local file. The metadata format is a strings with the
-    JSON-serialized dictionary that describes the metadata
+    to a dataset. A source can be: arguments, standard
+    input, or a local file.
+    The metadata format is a string with the JSON-serialized dictionary
+    that describes the metadata.
+
+    In case of an API-call metadata can also be provided in a python
+    dictionary directly.
 
     [TODO: add a schema]
 
@@ -96,40 +102,39 @@ class Add(Interface):
     in which case the pre-fixed argument is interpreted as a file-name and
     the argument value is read from the file.
 
+    The metadata key "dataset-id" must be identical to the ID of the dataset
+    that receives the metadata.
     """
 
     _examples_ = [
         dict(
             text='Add metadata stored in the file "metadata-123.json" to the '
-                 'metadata model instance in the current directory.',
+                 'dataset in the current directory.',
             code_cmd="datalad meta-add metadata-123.json"),
         dict(
             text='Add metadata stored in the file "metadata-123.json" to the '
-                 'metadata stored in the git-repository "/home/user/dataset_0"',
-            code_cmd="datalad meta-add --metadata-store /home/user/dataset_0 "
+                 'dataset "/home/user/dataset_0"',
+            code_cmd="datalad meta-add -d /home/user/dataset_0 "
                      "metadata-123.json"),
         dict(
             text='Add metadata stored in the file "metadata-123.json" to the '
-                 'metadata model instance in the current directory and '
-                 'overwrite the "dataset_id" value stored in '
-                 '"metadata-123.json"',
-            code_cmd='datalad meta-add --metadata-store /home/user/dataset_0 '
+                 'dataset in the current directory and overwrite the '
+                 '"dataset_id" value provided in "metadata-123.json"',
+            code_cmd='datalad meta-add -d /home/user/dataset_0 '
                      'metadata-123.json \'{"dataset_id": '
                      '"00010203-1011-2021-3031-404142434445"}\''
         ),
         dict(
-            text='Add metadata read from standard input to the metadata model '
-                 'instance in the current directory',
-            code_cmd='datalad meta-add --metadata-store /home/user/dataset_0 '
-                     'metadata-123.json @extra-info.json'
+            text='Add metadata read from standard input to the dataset '
+                 'in the current directory',
+            code_cmd='datalad meta-add -'
         ),
         dict(
             text='Add metadata stored in the file "metadata-123.json" to the '
-                 'metadata model instance in the current directory and '
-                 'overwrite metadata values with the values stored in '
+                 'dataset the current directory and overwrite the values'
+                 'from "metadata-123.json" with the values stored in '
                  '"extra-info.json"',
-            code_cmd='datalad meta-add --metadata-store /home/user/dataset_0 '
-                     'metadata-123.json @extra-info.json'
+            code_cmd='datalad meta-add metadata-123.json @extra-info.json'
         )
     ]
 
@@ -161,8 +166,8 @@ class Add(Interface):
         metadata=Parameter(
             args=("metadata",),
             metavar="METADATA",
-            doc=f"""Path of a file that contains the metadata that
-            should be added to the metadata model instance (the
+            doc=f"""path of the file that contains the
+            metadata that should be added to the metadata model instance (the
             metadata must be provided as a JSON-serialized metadata
             dictionary).
             
@@ -184,13 +189,6 @@ class Add(Interface):
             {required_additional_keys_lines}            
             """,
             constraints=EnsureStr() | EnsureNone()),
-        metadata_store=Parameter(
-            args=("-m", "--metadata-store"),
-            metavar="METADATA_STORE",
-            doc="""Directory in which the metadata model instance is
-            stored. If no directory name is provided, the current working
-            directory is used.""",
-            constraints=EnsureStr() | EnsureNone()),
         additionalvalues=Parameter(
             args=("additionalvalues",),
             metavar="ADDITIONAL_VALUES",
@@ -204,6 +202,12 @@ class Add(Interface):
             issued.""",
             nargs="?",
             constraints=EnsureStr() | EnsureNone()),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc=""""dataset to which metadata should be added. If not
+            provided, the dataset is assumed to be given by the current
+            directory.""",
+            constraints=EnsureDataset() | EnsureNone()),
         allow_override=Parameter(
             args=("-o", "--allow-override"),
             doc="""Allow the additional values to override values given in
@@ -214,7 +218,14 @@ class Add(Interface):
             args=("-u", "--allow-unknown"),
             doc="""Allow unknown keys. By default, unknown keys generate
             an errors. If this switch is True, unknown keys will only be
-            reported.""",
+            reported. For processing unknown keys will be ignored.""",
+            default=False,
+            constraints=EnsureBool() | EnsureNone()),
+        allow_id_mismatch=Parameter(
+            args=("-m", "--allow-id-mismatch"),
+            doc="""Allow insertion of metadata, even if the "dataset-id" in
+            the metadata source does not match the ID of the target
+            dataset.""",
             default=False,
             constraints=EnsureBool() | EnsureNone()))
 
@@ -223,23 +234,30 @@ class Add(Interface):
     @eval_results
     def __call__(
             metadata: Union[str, JSONObject],
-            metadata_store: Optional[str] = None,
             additionalvalues: Optional[Union[str, JSONObject]] = None,
+            dataset: Optional[Union[str, Dataset]] = None,
             allow_override: bool = False,
-            allow_unknown: bool = False):
+            allow_unknown: bool = False,
+            allow_id_mismatch: bool = False):
 
-        additionalvalues = additionalvalues or dict()
-        metadata_store = Path(metadata_store or curdir)
+        additional_values = additionalvalues or dict()
+
+        dataset = check_dataset(dataset or curdir, "add metadata")
 
         metadata = process_parameters(
             metadata=read_json_object(metadata),
-            additional_values=get_json_object(additionalvalues),
+            additional_values=get_json_object(additional_values),
             allow_override=allow_override,
             allow_unknown=allow_unknown)
 
-        lgr.debug(f"attempting to add metadata: {json.dumps(metadata)}")
+        lgr.debug(
+            f"attempting to add metadata: '{json.dumps(metadata)}' to "
+            f"dataset {dataset.pathobj}")
 
         add_parameter = AddParameter(
+            result_path=(
+                Path(metadata.get("dataset_path", "."))
+                / Path(metadata.get("path", ""))),
             dataset_id=UUID(metadata["dataset_id"]),
             dataset_version=metadata["dataset_version"],
             file_path=(
@@ -264,14 +282,21 @@ class Add(Interface):
 
             extracted_metadata=metadata["extracted_metadata"])
 
+        error_result = check_dataset_ids(dataset, add_parameter)
+        if error_result:
+            if not allow_id_mismatch:
+                yield error_result
+                return
+            lgr.warning(error_result["message"])
+
         # If the key "path" is present in the metadata
         # dictionary, we assume that the metadata-dictionary describes
         # file-level metadata. Otherwise, we assume that the
         # metadata-dictionary contains dataset-level metadata.
         if add_parameter.file_path:
-            yield from add_file_metadata(metadata_store, add_parameter)
+            yield from add_file_metadata(dataset.pathobj, add_parameter)
         else:
-            yield from add_dataset_metadata(metadata_store, add_parameter)
+            yield from add_dataset_metadata(dataset.pathobj, add_parameter)
         return
 
 
@@ -371,6 +396,25 @@ def process_parameters(metadata: dict,
         raise MetadataKeyException(f"Unknown type {metadata['type']}")
 
     return metadata
+
+
+def check_dataset_ids(dataset, add_parameter: AddParameter) -> Optional[dict]:
+    if add_parameter.root_dataset_id is not None:
+        if add_parameter.root_dataset_id != UUID(dataset.id):
+            return dict(
+                action="meta-add",
+                status="error",
+                path=add_parameter.result_path,
+                message='provided "root-dataset-id" does not match ID of '
+                        'dataset {dataset.path}')
+    else:
+        if add_parameter.dataset_id != UUID(dataset.id):
+            return dict(
+                action="meta-add",
+                status="error",
+                path=add_parameter.result_path,
+                message='provided "dataset-id" does not match ID of '
+                        'dataset {dataset.path}')
 
 
 def _get_top_nodes(realm: str, ap: AddParameter):

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -27,7 +27,6 @@ from datalad.interface.utils import eval_results
 from datalad.distribution.dataset import (
     datasetmethod,
     EnsureDataset,
-    require_dataset,
 )
 from datalad.metadata.extractors.base import BaseMetadataExtractor
 from datalad.support.exceptions import NoDatasetFound
@@ -50,7 +49,7 @@ from datalad.support.param import Parameter
 
 from dataladmetadatamodel.metadatapath import MetadataPath
 
-from .utils import args_to_dict
+from .utils import args_to_dict, check_dataset
 
 
 __docformat__ = "restructuredtext"
@@ -192,21 +191,7 @@ class Extract(Interface):
         extractor_args = extractorargs
         path = None if path == "++" else path
 
-        source_dataset = require_dataset(
-            dataset or curdir,
-            purpose="extract metadata",
-            check_installed=path is not None)
-
-        if not source_dataset.repo:
-            raise NoDatasetFound(
-                "No valid datalad dataset found at: "
-                f"{Path(dataset or curdir).resolve()}")
-
-        if source_dataset.id is None:
-            raise NoDatasetFound(
-                "No valid datalad-id found in dataset at: "
-                f"{Path(dataset or curdir).resolve()}")
-
+        source_dataset = check_dataset(dataset or curdir, "extract metadata")
         source_dataset_version = source_dataset.repo.get_hexsha()
 
         extractor_class = get_extractor_class(extractor_name)

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -386,7 +386,6 @@ def _get_metadata_content(metadata):
     return instances[0].metadata_content
 
 
-@skip_if_on_windows
 @with_tempfile
 def test_add_dataset_end_to_end(file_name):
     json.dump({
@@ -415,7 +414,6 @@ def test_add_dataset_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
-@skip_if_on_windows
 @with_tempfile
 def test_add_file_end_to_end(file_name):
 
@@ -450,7 +448,6 @@ def test_add_file_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
-@skip_if_on_windows
 @with_tempfile
 def test_subdataset_add_dataset_end_to_end(file_name):
 
@@ -494,7 +491,6 @@ def test_subdataset_add_dataset_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
-@skip_if_on_windows
 @with_tempfile
 def test_subdataset_add_file_end_to_end(file_name):
 
@@ -544,7 +540,6 @@ def test_subdataset_add_file_end_to_end(file_name):
         eq_(metadata_content, metadata_template["extracted_metadata"])
 
 
-@skip_if_on_windows
 @with_tempfile
 def test_current_dir_add_end_to_end(file_name):
 

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -24,7 +24,6 @@ from datalad.tests.utils import (
     assert_result_count,
     assert_true,
     eq_,
-    skip_if_on_windows,
     with_tempfile
 )
 

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -16,7 +16,6 @@ from uuid import UUID
 
 from datalad.api import meta_add, meta_aggregate, meta_dump
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.support.gitrepo import GitRepo
 from datalad.tests.utils import assert_raises, assert_result_count, eq_
 
 from .utils import create_dataset
@@ -132,9 +131,9 @@ def test_missing_metadata_stores():
         subdataset_0_dir = root_dataset_dir / "subdataset_0"
         subdataset_1_dir = root_dataset_dir / "subdataset_1"
 
-        root_git_repo = create_dataset(root_dataset_dir, root_id)
-        subdataset_0_repo = create_dataset(subdataset_0_dir, sub_0_id)
-        subdataset_1_repo = create_dataset(subdataset_1_dir, sub_1_id)
+        create_dataset(root_dataset_dir, root_id)
+        create_dataset(subdataset_0_dir, sub_0_id)
+        create_dataset(subdataset_1_dir, sub_1_id)
 
         assert_raises(
             InsufficientArgumentsError,
@@ -153,12 +152,13 @@ def test_basic_aggregation_into_empty_store():
         subdataset_0_dir = root_dataset_dir / "subdataset_0"
         subdataset_1_dir = root_dataset_dir / "subdataset_1"
 
-        root_git_repo = create_dataset(root_dataset_dir, root_id)
-        subdataset_0_repo = create_dataset(subdataset_0_dir, sub_0_id)
-        subdataset_1_repo = create_dataset(subdataset_1_dir, sub_1_id)
+        create_dataset(root_dataset_dir, root_id)
+        create_dataset(subdataset_0_dir, sub_0_id)
+        create_dataset(subdataset_1_dir, sub_1_id)
 
-        # TODO: there is a dependency here in meta_add. We should instead
-        #  use the model API to add metadata to metadata stores
+        # TODO: this is more an end-to-end test, since we depend
+        #  meta_add. We should instead use the model API to add
+        #  metadata to metadata stores
 
         for index in range(2):
             _add_dataset_level_metadata(
@@ -180,7 +180,7 @@ def test_basic_aggregation_into_empty_store():
             # Ensure that the root version is found
             p.return_value = ["0000000000000000000000000000000000000aaa"]
 
-            result = meta_aggregate(
+            meta_aggregate(
                 str(root_dataset_dir),
                 [
                     "subdataset_0", str(subdataset_0_dir),
@@ -195,7 +195,9 @@ def test_basic_aggregation_into_empty_store():
             for index, result in enumerate(result_objects):
                 result_object = result["metadata"]["dataset_level_metadata"]
                 eq_(result_object["root_dataset_identifier"], "<unknown>")
-                eq_(result_object["root_dataset_version"], "0000000000000000000000000000000000000aaa")
+                eq_(
+                    result_object["root_dataset_version"],
+                    "0000000000000000000000000000000000000aaa")
 
                 eq_(result_object["dataset_identifier"],
                     [

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -64,10 +64,7 @@ def test_basic_aggregation():
 
             result = meta_aggregate(
                 str(root_dataset_dir),
-                [
-                    "subdataset_0", str(subdataset_0_dir),
-                    "subdataset_1", str(subdataset_1_dir)
-                ])
+                [str(subdataset_0_dir), str(subdataset_1_dir)])
 
             result_objects = meta_dump(
                 dataset=str(root_dataset_dir),
@@ -117,10 +114,7 @@ def test_missing_metadata_stores():
             InsufficientArgumentsError,
             meta_aggregate,
             str(root_dataset_dir),
-            [
-                "subdataset_0", str(subdataset_0_dir),
-                "subdataset_1", str(subdataset_1_dir)
-            ])
+            [str(subdataset_0_dir), str(subdataset_1_dir)])
 
 
 def test_basic_aggregation_into_empty_store():
@@ -160,10 +154,7 @@ def test_basic_aggregation_into_empty_store():
 
             meta_aggregate(
                 str(root_dataset_dir),
-                [
-                    "subdataset_0", str(subdataset_0_dir),
-                    "subdataset_1", str(subdataset_1_dir)
-                ])
+                [str(subdataset_0_dir), str(subdataset_1_dir)])
 
             result_objects = meta_dump(
                 dataset=str(root_dataset_dir),

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -18,34 +18,12 @@ from datalad.api import meta_add, meta_aggregate, meta_dump
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.tests.utils import assert_raises, assert_result_count, eq_
 
-from .utils import create_dataset
+from .utils import add_dataset_level_metadata, create_dataset
 
 
 root_id = UUID("00010203-1011-2021-3031-404142434445")
 sub_0_id = UUID("a0cc0203-1011-2021-3031-404142434445")
 sub_1_id = UUID("a1cc0203-1011-2021-3031-404142434445")
-
-
-def _add_dataset_level_metadata(metadata_store: Path,
-                                dataset_id: str,
-                                dataset_version: str,
-                                metadata_content: str):
-    meta_add(
-        {
-            "type": "dataset",
-            "extractor_name": "test_dataset",
-            "extractor_version": "1.0",
-            "extraction_parameter": {},
-            "extraction_time": "1000.1",
-            "agent_name": "test_aggregate",
-            "agent_email": "test@test.aggregate",
-            "dataset_id": dataset_id,
-            "dataset_version": dataset_version,
-            "extracted_metadata": {
-                "content": metadata_content
-            }
-        },
-        dataset=metadata_store)
 
 
 def test_basic_aggregation():
@@ -55,15 +33,15 @@ def test_basic_aggregation():
         subdataset_0_dir = root_dataset_dir / "subdataset_0"
         subdataset_1_dir = root_dataset_dir / "subdataset_1"
 
-        root_git_repo = create_dataset(root_dataset_dir, root_id)
-        subdataset_0_repo = create_dataset(subdataset_0_dir, sub_0_id)
-        subdataset_1_repo = create_dataset(subdataset_1_dir, sub_1_id)
+        create_dataset(root_dataset_dir, root_id)
+        create_dataset(subdataset_0_dir, sub_0_id)
+        create_dataset(subdataset_1_dir, sub_1_id)
 
         # TODO: there is a dependency here in meta_add. We should instead
         #  use the model API to add metadata to metadata stores
 
         for index in range(3):
-            _add_dataset_level_metadata(
+            add_dataset_level_metadata(
                 metadata_store=[
                     root_dataset_dir,
                     subdataset_0_dir,
@@ -92,7 +70,7 @@ def test_basic_aggregation():
                 ])
 
             result_objects = meta_dump(
-                metadata_store=str(root_dataset_dir),
+                dataset=str(root_dataset_dir),
                 recursive=True)
 
             assert_result_count(result_objects, 3)
@@ -157,11 +135,11 @@ def test_basic_aggregation_into_empty_store():
         create_dataset(subdataset_1_dir, sub_1_id)
 
         # TODO: this is more an end-to-end test, since we depend
-        #  meta_add. We should instead use the model API to add
+        #  on meta_add. We should instead use the model API to add
         #  metadata to metadata stores
 
         for index in range(2):
-            _add_dataset_level_metadata(
+            add_dataset_level_metadata(
                 metadata_store=[
                     subdataset_0_dir,
                     subdataset_1_dir
@@ -188,7 +166,7 @@ def test_basic_aggregation_into_empty_store():
                 ])
 
             result_objects = meta_dump(
-                metadata_store=str(root_dataset_dir),
+                dataset=str(root_dataset_dir),
                 recursive=True)
 
             assert_result_count(result_objects, 2)

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from unittest.mock import patch
 from uuid import UUID
 
-from datalad.api import meta_add, meta_aggregate, meta_dump
+from datalad.api import meta_aggregate, meta_dump
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.tests.utils import assert_raises, assert_result_count, eq_
 

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -1,10 +1,14 @@
 from pathlib import Path
+from typing import Optional
 from uuid import UUID
 
+from dataladmetadatamodel.metadatapath import MetadataPath
+
+from datalad.api import meta_add
 from datalad.support.gitrepo import GitRepo
 
 
-def create_dataset(directory: str, id: UUID) -> GitRepo:
+def create_dataset(directory: str, dataset_id: UUID) -> GitRepo:
 
     git_repo = GitRepo(directory)
 
@@ -15,8 +19,93 @@ def create_dataset(directory: str, id: UUID) -> GitRepo:
     datalad_config = datalad_dir / "config"
     datalad_config.write_text(
         '[datalad "dataset"]\n'
-        f'\tid = {id}')
+        f'\tid = {dataset_id}')
 
     return git_repo
 
 
+common_elements = {
+    "extractor_name": "test_dataset",
+    "extractor_version": "1.0",
+    "extraction_parameter": {},
+    "extraction_time": "1000.1",
+    "agent_name": "test_aggregate",
+    "agent_email": "test@test.aggregate"
+}
+
+
+def _get_base_elements(dataset_id: str,
+                       dataset_version: str,
+                       metadata_content: str,
+                       root_dataset_id: Optional[str] = None,
+                       root_dataset_version: Optional[str] = None,
+                       dataset_path: Optional[str] = None) -> dict:
+
+    if root_dataset_id is not None:
+        assert root_dataset_version is not None
+        assert dataset_path is not None
+        root_info = {
+            "root_dataset_id": root_dataset_id,
+            "root_dataset_version": root_dataset_version,
+            "dataset_path": str(dataset_path),
+        }
+    else:
+        root_info = {}
+
+    return {
+        **common_elements,
+        "dataset_id": dataset_id,
+        "dataset_version": dataset_version,
+        "extracted_metadata": {
+            "content": metadata_content
+        },
+        **root_info
+    }
+
+
+def add_dataset_level_metadata(metadata_store: Path,
+                               dataset_id: str,
+                               dataset_version: str,
+                               metadata_content: str,
+                               root_dataset_id: Optional[str] = None,
+                               root_dataset_version: Optional[str] = None,
+                               dataset_path: Optional[str] = None):
+
+    base_elements = _get_base_elements(
+        dataset_id,
+        dataset_version,
+        metadata_content,
+        root_dataset_id,
+        root_dataset_version,
+        dataset_path)
+
+    meta_add({
+            **base_elements,
+            "type": "dataset"
+        },
+        dataset=metadata_store)
+
+
+def add_file_level_metadata(metadata_store: Path,
+                            dataset_id: str,
+                            dataset_version: str,
+                            file_path: MetadataPath,
+                            metadata_content: str,
+                            root_dataset_id: Optional[str] = None,
+                            root_dataset_version: Optional[str] = None,
+                            dataset_path: Optional[str] = None):
+
+    base_elements = _get_base_elements(
+        dataset_id,
+        dataset_version,
+        metadata_content,
+        root_dataset_id,
+        root_dataset_version,
+        dataset_path)
+
+    meta_add({
+            **base_elements,
+            "type": "file",
+            "path": str(file_path)
+        },
+        dataset=metadata_store)

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from uuid import UUID
+
+from datalad.support.gitrepo import GitRepo
+
+
+def create_dataset(directory: str, id: UUID) -> GitRepo:
+
+    git_repo = GitRepo(directory)
+
+    git_repo_path = Path(git_repo.path)
+    datalad_dir = git_repo_path / ".datalad"
+    datalad_dir.mkdir()
+
+    datalad_config = datalad_dir / "config"
+    datalad_config.write_text(
+        '[datalad "dataset"]\n'
+        f'\tid = {id}')
+
+    return git_repo
+
+

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -123,7 +123,7 @@ def get_add_cmdline(metadata_store: Path,
     command_line = ["datalad"]
     if arguments.log_level:
         command_line.extend(["-l", arguments.log_level])
-    command_line.extend(["meta-add", "-m", str(metadata_store), "-"])
+    command_line.extend(["meta-add", "-d", str(metadata_store), "-"])
 
     if "root_dataset_id" in context:
         additional_values = {


### PR DESCRIPTION
This PR fixes #119 , #115 , and #97 

Metadata-store is no longer used in the API (cmdline and coreapi). Instead we assume that metadata over elements of a dataset is stored in the git-repo of that dataset