### PR TITLE
Fix result structure

### DIFF
--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -235,9 +235,11 @@ class Aggregate(Interface):
         yield dict(
             action="meta_aggregate",
             status='ok',
+            path=root_realm,
+            destination=root_realm,
+            sources=[str(pam[1]) for pam in path_realm_associations],
             backend=backend,
-            metadata_store=root_realm,
-            message="aggregation performed")
+            message=f"aggregated metadata into {root_realm}")
 
         return
 

--- a/datalad_metalad/dump.py
+++ b/datalad_metalad/dump.py
@@ -75,7 +75,7 @@ def _file_report_matcher(tree_node: TreeNode) -> bool:
 def _create_result_record(mapper: str,
                           metadata_store: str,
                           metadata_record: JSONObject,
-                          element_path: str,
+                          element_path: Path,
                           report_type: str):
     return {
         "status": "ok",

--- a/datalad_metalad/dump.py
+++ b/datalad_metalad/dump.py
@@ -88,11 +88,33 @@ def _create_result_record(mapper: str,
     }
 
 
-def _create_metadata_instance_record(instance: MetadataInstance) -> dict:
+def _get_common_properties(root_dataset_identifier: UUID,
+                           root_dataset_version: str,
+                           metadata_root_record: MetadataRootRecord,
+                           dataset_path: MetadataPath) -> dict:
+
+    if dataset_path != MetadataPath(""):
+        root_info = {
+            "root_dataset_id": str(root_dataset_identifier),
+            "root_dataset_version": root_dataset_version,
+            "dataset_path": str(dataset_path)}
+    else:
+        root_info = {}
+
+    return {
+        **root_info,
+        "dataset_id": str(metadata_root_record.dataset_identifier),
+        "dataset_version": metadata_root_record.dataset_version
+    }
+
+
+def _get_instance_properties(extractor_name: str,
+                             instance: MetadataInstance) -> dict:
     return {
         "extraction_time": instance.time_stamp,
         "agent_name": instance.author_name,
         "agent_email": instance.author_email,
+        "extractor_name": extractor_name,
         "extractor_version": instance.configuration.version,
         "extraction_parameter": instance.configuration.parameter,
         "extracted_metadata": instance.metadata_content
@@ -116,34 +138,29 @@ def show_dataset_metadata(mapper: str,
             f"uuid:{root_dataset_identifier}@{root_dataset_version}")
         return
 
-    result_json_object = {
-        "dataset_level_metadata": {
-            "root_dataset_metadata_store": metadata_store,
-            "root_dataset_id": str(root_dataset_identifier),
-            "root_dataset_version": root_dataset_version,
-            "dataset_id": str(metadata_root_record.dataset_identifier),
-            "dataset_version": metadata_root_record.dataset_version,
-            "dataset_path": str(dataset_path),
-        }
-    }
+    common_properties = _get_common_properties(
+        root_dataset_identifier,
+        root_dataset_version,
+        metadata_root_record,
+        dataset_path)
 
     for extractor_name, extractor_runs in dataset_level_metadata.extractor_runs():
+        for instance in extractor_runs:
 
-        instances = [
-            _create_metadata_instance_record(instance)
-            for instance in extractor_runs
-        ]
+            instance_properties = _get_instance_properties(
+                extractor_name,
+                instance)
 
-        result_json_object["dataset_level_metadata"]["metadata"] = {
-            extractor_name: instances
-        }
-
-        yield _create_result_record(
-            mapper=mapper,
-            metadata_store=metadata_store,
-            metadata_record=result_json_object,
-            element_path=dataset_path,
-            report_type="dataset")
+            yield _create_result_record(
+                mapper=mapper,
+                metadata_store=metadata_store,
+                metadata_record={
+                    "type": "dataset",
+                    **common_properties,
+                    **instance_properties
+                },
+                element_path=dataset_path,
+                report_type="dataset")
 
     # Remove dataset-level metadata when we are done with it
     metadata_root_record.dataset_level_metadata.purge()
@@ -183,35 +200,31 @@ def show_file_tree_metadata(mapper: str,
         if metadata_connector is None:
             continue
 
+        common_properties = _get_common_properties(
+            root_dataset_identifier,
+            root_dataset_version,
+            metadata_root_record,
+            dataset_path)
+
         metadata = metadata_connector.load_object()
-        result_json_object = {
-            "file_level_metadata": {
-                "root_dataset_id": str(root_dataset_identifier),
-                "root_dataset_version": root_dataset_version,
-                "dataset_id": str(
-                    metadata_root_record.dataset_identifier),
-                "dataset_version": metadata_root_record.dataset_version,
-                "dataset_path": str(dataset_path),
-                "path": str(path)
-            }
-        }
-
         for extractor_name, extractor_runs in metadata.extractor_runs():
-            instances = [
-                _create_metadata_instance_record(instance)
-                for instance in extractor_runs
-            ]
+            for instance in extractor_runs:
 
-            result_json_object["file_level_metadata"]["metadata"] = {
-                extractor_name: instances
-            }
+                instance_properties = _get_instance_properties(
+                    extractor_name,
+                    instance)
 
-            yield _create_result_record(
-                mapper=mapper,
-                metadata_store=metadata_store,
-                metadata_record=result_json_object,
-                element_path=dataset_path / path,
-                report_type="file")
+                yield _create_result_record(
+                    mapper=mapper,
+                    metadata_store=metadata_store,
+                    metadata_record={
+                        "type": "file",
+                        "path": str(path),
+                        **common_properties,
+                        **instance_properties
+                    },
+                    element_path=dataset_path / path,
+                    report_type="dataset")
 
         # Remove metadata object after all instances are reported
         metadata_connector.purge()
@@ -478,59 +491,4 @@ class Dump(Interface):
             # logging complained about this already
             return
 
-        render_dataset_level_metadata(
-            res["metadata"].get("dataset_level_metadata", dict()))
-
-        render_file_level_metadata(
-            res["metadata"].get("file_level_metadata", dict()))
-
-
-def render_dataset_level_metadata(dl_metadata: dict):
-    if not dl_metadata:
-        return
-
-    result_base = dict(
-        type="dataset",
-        dataset_id=dl_metadata["dataset_id"],
-        dataset_version=dl_metadata["dataset_version"])
-
-    render_common_metadata(dl_metadata, result_base)
-
-
-def render_file_level_metadata(fl_metadata: dict):
-    if not fl_metadata:
-        return
-
-    result_base = dict(
-        type="file",
-        dataset_id=fl_metadata["dataset_id"],
-        dataset_version=fl_metadata["dataset_version"],
-        path=fl_metadata["path"])
-
-    render_common_metadata(fl_metadata, result_base)
-
-
-def render_common_metadata(metadata: dict, result_base: dict):
-
-    if result_base["dataset_version"] != metadata["root_dataset_version"]:
-        assert metadata["dataset_path"] != ""
-        result_base["root_dataset_id"] = metadata["root_dataset_id"]
-        result_base["root_dataset_version"] = metadata[
-            "root_dataset_version"]
-        result_base["dataset_path"] = metadata["dataset_path"]
-
-    for extractor_name, extractions in metadata["metadata"].items():
-        for extraction in extractions:
-            extraction_result = dict(
-                extractor_name=extractor_name,
-                extractor_version=extraction["extractor_version"],
-                extraction_parameter=extraction["extraction_parameter"],
-                extraction_time=extraction["extraction_time"],
-                agent_name=extraction["agent_name"],
-                agent_email=extraction["agent_email"],
-                extracted_metadata=extraction["extracted_metadata"])
-
-            ui.message(json.dumps({
-                **result_base,
-                **extraction_result
-            }))
+        ui.message(json.dumps(res["metadata"]))

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -569,14 +569,9 @@ def test_current_dir_add_end_to_end(file_name):
 
         assert_true(len(results), 1)
         result = results[0]["metadata"]["dataset_level_metadata"]
-        eq_(result["root_dataset_identifier"], str(default_id))
-        eq_(result["dataset_identifier"], str(another_id))
+        eq_(result["root_dataset_id"], str(default_id))
+        eq_(result["dataset_id"], str(another_id))
 
         metadata = result["metadata"]["ex_extractor_name"][0]
-        translate = {
-            "extraction_agent_name": "agent_name",
-            "extraction_agent_email": "agent_email",
-            "extraction_result": "extracted_metadata"
-        }
         for key, value in metadata.items():
-            eq_(value, metadata_template[translate.get(key, key)])
+            eq_(value, metadata_template[key])

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from datalad.api import meta_add, meta_dump
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import (
+    assert_dict_equal,
     assert_is_not_none,
     assert_raises,
     assert_result_count,
@@ -568,10 +569,20 @@ def test_current_dir_add_end_to_end(file_name):
         results = tuple(meta_dump(dataset=git_repo.pathobj, recursive=True))
 
         assert_true(len(results), 1)
-        result = results[0]["metadata"]["dataset_level_metadata"]
-        eq_(result["root_dataset_id"], str(default_id))
-        eq_(result["dataset_id"], str(another_id))
+        result = results[0]["metadata"]
 
-        metadata = result["metadata"]["ex_extractor_name"][0]
-        for key, value in metadata.items():
-            eq_(value, metadata_template[key])
+        expected = {
+            **metadata_template,
+            **additional_keys_template,
+            "type": "dataset",
+            "dataset_id": str(another_id),
+        }
+
+        # Check extraction parameter result
+        ep_key = "extraction_parameter"
+        assert_dict_equal(expected[ep_key], result[ep_key])
+        del expected[ep_key]
+        del result[ep_key]
+
+        # Check remaining result
+        assert_dict_equal(result, expected)

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -73,12 +73,12 @@ def test_basic_aggregation():
             assert_result_count(result_objects, 3)
             for index, result in enumerate(result_objects):
                 result_object = result["metadata"]["dataset_level_metadata"]
-                eq_(result_object["root_dataset_identifier"], str(root_id))
+                eq_(result_object["root_dataset_id"], str(root_id))
 
                 eq_(result_object["root_dataset_version"],
                     "0000000000000000000000000000000000000000")
 
-                eq_(result_object["dataset_identifier"], [
+                eq_(result_object["dataset_id"], [
                     str(root_id),
                     str(sub_0_id),
                     str(sub_1_id)
@@ -95,7 +95,7 @@ def test_basic_aggregation():
 
                 metadata_content = result_object["metadata"]["test_dataset"][0]
 
-                eq_(metadata_content["extraction_result"]["content"],
+                eq_(metadata_content["extracted_metadata"]["content"],
                     f"metadata-content_{index}")
 
 
@@ -163,12 +163,12 @@ def test_basic_aggregation_into_empty_store():
             assert_result_count(result_objects, 2)
             for index, result in enumerate(result_objects):
                 result_object = result["metadata"]["dataset_level_metadata"]
-                eq_(result_object["root_dataset_identifier"], "<unknown>")
+                eq_(result_object["root_dataset_id"], "<unknown>")
                 eq_(
                     result_object["root_dataset_version"],
                     "0000000000000000000000000000000000000aaa")
 
-                eq_(result_object["dataset_identifier"],
+                eq_(result_object["dataset_id"],
                     [
                         str(sub_0_id),
                         str(sub_1_id)
@@ -184,5 +184,5 @@ def test_basic_aggregation_into_empty_store():
 
                 metadata_content = result_object["metadata"]["test_dataset"][0]
 
-                eq_(metadata_content["extraction_result"]["content"],
+                eq_(metadata_content["extracted_metadata"]["content"],
                     f"metadata-content_{index}")

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -11,12 +11,15 @@
 
 import tempfile
 from pathlib import Path
+from typing import Optional
 from unittest.mock import patch
 from uuid import UUID
 
+
 from datalad.api import meta_aggregate, meta_dump
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import assert_raises, assert_result_count, eq_
+from datalad.tests.utils import assert_not_in, assert_raises, \
+    assert_result_count, eq_
 
 from .utils import add_dataset_level_metadata, create_dataset
 
@@ -24,6 +27,27 @@ from .utils import add_dataset_level_metadata, create_dataset
 root_id = UUID("00010203-1011-2021-3031-404142434445")
 sub_0_id = UUID("a0cc0203-1011-2021-3031-404142434445")
 sub_1_id = UUID("a1cc0203-1011-2021-3031-404142434445")
+
+version_base = "000000000000000000000000000000000000000{index}"
+
+
+def _check_root_elements(result_object: dict,
+                         dataset_path: Optional[str],
+                         root_dataset_id: Optional[str],
+                         root_dataset_version: Optional[str]):
+
+    if dataset_path is None:
+        # Ensure that identical values, i.e. dataset_id and
+        # dataset_version, and empty values, i.e. dataset_path, are
+        # not present in the result.
+        assert_not_in("root_dataset_id", result_object)
+        assert_not_in("root_dataset_version", result_object)
+        assert_not_in("dataset_path", result_object)
+
+    else:
+        eq_(result_object["root_dataset_id"], root_dataset_id)
+        eq_(result_object["root_dataset_version"], root_dataset_version)
+        eq_(result_object["dataset_path"], dataset_path)
 
 
 def test_basic_aggregation():
@@ -52,7 +76,7 @@ def test_basic_aggregation():
                     str(sub_0_id),
                     str(sub_1_id)
                 ][index],
-                dataset_version=f"000000000000000000000000000000000000000{index}",
+                dataset_version=version_base.format(index=index),
                 metadata_content=f"metadata-content_{index}")
 
         # We have to patch "get_root_version_for_subset_version" because
@@ -60,7 +84,7 @@ def test_basic_aggregation():
         with patch("datalad_metalad.aggregate.get_root_version_for_subset_version") as p:
 
             # Ensure that the root version is found
-            p.return_value = ["0000000000000000000000000000000000000000"]
+            p.return_value = [version_base.format(index=0)]
 
             result = meta_aggregate(
                 str(root_dataset_dir),
@@ -71,12 +95,21 @@ def test_basic_aggregation():
                 recursive=True)
 
             assert_result_count(result_objects, 3)
-            for index, result in enumerate(result_objects):
-                result_object = result["metadata"]["dataset_level_metadata"]
-                eq_(result_object["root_dataset_id"], str(root_id))
 
-                eq_(result_object["root_dataset_version"],
-                    "0000000000000000000000000000000000000000")
+            zero_version = version_base.format(index=0)
+            check_parameters = [
+                dict(dataset_path=None, root_dataset_id=None),
+                dict(dataset_path="subdataset_0", root_dataset_id=str(root_id)),
+                dict(dataset_path="subdataset_1", root_dataset_id=str(root_id))
+            ]
+
+            for index, result in enumerate(result_objects):
+                result_object = result["metadata"]
+
+                _check_root_elements(
+                    result_object=result_object,
+                    root_dataset_version=zero_version,
+                    **(check_parameters[index]))
 
                 eq_(result_object["dataset_id"], [
                     str(root_id),
@@ -84,18 +117,12 @@ def test_basic_aggregation():
                     str(sub_1_id)
                 ][index])
 
-                eq_(result_object["dataset_version"],
-                    f"000000000000000000000000000000000000000{index}")
+                eq_(
+                    result_object["dataset_version"],
+                    version_base.format(index=index))
 
-                eq_(result_object["dataset_path"], [
-                    "",
-                    "subdataset_0",
-                    "subdataset_1"
-                ][index])
-
-                metadata_content = result_object["metadata"]["test_dataset"][0]
-
-                eq_(metadata_content["extracted_metadata"]["content"],
+                eq_(result_object["extractor_name"], "test_dataset")
+                eq_(result_object["extracted_metadata"]["content"],
                     f"metadata-content_{index}")
 
 
@@ -142,7 +169,7 @@ def test_basic_aggregation_into_empty_store():
                     str(sub_0_id),
                     str(sub_1_id)
                 ][index],
-                dataset_version=f"000000000000000000000000000000000000000{index}",
+                dataset_version=version_base.format(index=index),
                 metadata_content=f"metadata-content_{index}")
 
         # We have to patch "get_root_version_for_subset_version" because
@@ -150,7 +177,7 @@ def test_basic_aggregation_into_empty_store():
         with patch("datalad_metalad.aggregate.get_root_version_for_subset_version") as p:
 
             # Ensure that the root version is found
-            p.return_value = ["0000000000000000000000000000000000000aaa"]
+            p.return_value = [version_base.format(index="a")]
 
             meta_aggregate(
                 str(root_dataset_dir),
@@ -161,12 +188,20 @@ def test_basic_aggregation_into_empty_store():
                 recursive=True)
 
             assert_result_count(result_objects, 2)
+
+            a_version = version_base.format(index="a")
+            check_parameters = [
+                dict(dataset_path="subdataset_0", root_dataset_id="<unknown>"),
+                dict(dataset_path="subdataset_1", root_dataset_id="<unknown>")
+            ]
+
             for index, result in enumerate(result_objects):
-                result_object = result["metadata"]["dataset_level_metadata"]
-                eq_(result_object["root_dataset_id"], "<unknown>")
-                eq_(
-                    result_object["root_dataset_version"],
-                    "0000000000000000000000000000000000000aaa")
+
+                result_object = result["metadata"]
+                _check_root_elements(
+                    result_object=result_object,
+                    root_dataset_version=a_version,
+                    **(check_parameters[index]))
 
                 eq_(result_object["dataset_id"],
                     [
@@ -174,15 +209,10 @@ def test_basic_aggregation_into_empty_store():
                         str(sub_1_id)
                     ][index])
 
-                eq_(result_object["dataset_version"],
-                    f"000000000000000000000000000000000000000{index}")
+                eq_(
+                    result_object["dataset_version"],
+                    version_base.format(index=index))
 
-                eq_(result_object["dataset_path"], [
-                    "subdataset_0",
-                    "subdataset_1"
-                ][index])
-
-                metadata_content = result_object["metadata"]["test_dataset"][0]
-
-                eq_(metadata_content["extracted_metadata"]["content"],
+                eq_(result_object["extractor_name"], "test_dataset")
+                eq_(result_object["extracted_metadata"]["content"],
                     f"metadata-content_{index}")


### PR DESCRIPTION
This fixes issue #84 and issue #85 

The dump result record now contains the result that is emitted by the custom renderer as verbatim value in the key "metadata".
