### PR TITLE
meta-conduct: return JSON-encoded results

### DIFF
--- a/datalad_metalad/conduct.py
+++ b/datalad_metalad/conduct.py
@@ -219,7 +219,7 @@ def process_parallel(executor,
                 status="ok",
                 path=str(path),
                 logger=lgr,
-                pipeline_element=pipeline_element)
+                pipeline_element=pipeline_element.to_json())
             continue
 
         lgr.debug(f"Starting instance {processor_instances[0]} on {pipeline_element}")
@@ -249,7 +249,7 @@ def process_parallel(executor,
                             status="ok",
                             path=str(path),
                             logger=lgr,
-                            pipeline_element=pipeline_element)
+                            pipeline_element=pipeline_element.to_json())
                 else:
                     lgr.debug(
                         f"Starting processor[{next_index}]"
@@ -296,7 +296,7 @@ def process_parallel(executor,
                             status="ok",
                             path=str(path),
                             logger=lgr,
-                            pipeline_element=pipeline_element)
+                            pipeline_element=pipeline_element.to_json())
                 else:
                     lgr.debug(
                         f"Handing pipeline element {pipeline_element} to"
@@ -365,7 +365,7 @@ def process_downstream(pipeline_element: PipelineElement,
             status="ok",
             path=str(path),
             logger=lgr,
-            pipeline_element=pipeline_element)
+            pipeline_element=pipeline_element.to_json())
 
         lgr.debug(
             f"Pipeline finished, returning datalad result {datalad_result}")

--- a/datalad_metalad/pipelineelement.py
+++ b/datalad_metalad/pipelineelement.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 from enum import Enum
 from dataclasses import dataclass, field
@@ -23,6 +24,14 @@ class PipelineResult:
     def __post_init__(self):
         self.message = ""
         self.base_error = None
+
+    def to_json(self) -> Dict:
+        result = dict(state=self.state.name)
+        if self.base_error is not None:
+            result["error"] = self.base_error
+        if self.message:
+            result["message"] = self.message
+        return result
 
 
 class PipelineElement:
@@ -67,3 +76,18 @@ class PipelineElement:
             "state": self.state.name,
             "result": self._result
         })
+
+    def to_json(self) -> Dict:
+        json_obj = {
+            "state": self.state.name,
+            "result": {
+                key: [
+                    result.to_json()
+                    for result in value
+                ]
+                for key, value in self._result.items()
+                if key not in ("path",)
+            }
+        }
+        json_obj["result"]["path"] = str(self._result["path"])
+        return json_obj

--- a/datalad_metalad/processor/add.py
+++ b/datalad_metalad/processor/add.py
@@ -26,6 +26,12 @@ logger = logging.getLogger("datalad.metadata.processor.add")
 class MetadataAddResult(PipelineResult):
     path: str
 
+    def to_json(self) -> Dict:
+        return {
+            **super().to_json(),
+            "path": str(self.path)
+        }
+
 
 class MetadataAdder(Processor):
     def __init__(self,

--- a/datalad_metalad/processor/extract.py
+++ b/datalad_metalad/processor/extract.py
@@ -36,6 +36,13 @@ class MetadataExtractorResult(PipelineResult):
     context: Optional[Dict] = None
     metadata_record: Optional[Dict] = field(init=False)
 
+    def to_json(self) -> Dict:
+        return {
+            **super().to_json(),
+            "path": str(self.path),
+            "metadata_record": self.metadata_record
+        }
+
 
 class MetadataExtractor(Processor):
     def __init__(self,

--- a/datalad_metalad/tests/test_conduct.py
+++ b/datalad_metalad/tests/test_conduct.py
@@ -12,6 +12,7 @@ import tempfile
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
+from typing import Dict
 
 from datalad.api import meta_conduct
 from datalad.tests.utils import (
@@ -87,6 +88,12 @@ class TestResult(PipelineResult):
 @dataclass
 class StringResult(PipelineResult):
     content: str
+
+    def to_json(self) -> Dict:
+        return {
+            **super().to_json(),
+            "content": self.content
+        }
 
 
 class TestTraverser(Provider):
@@ -184,7 +191,7 @@ def test_extract():
 
         # Ensure that each pipeline element carries two metadata results,
         # one from each extractor in the pipeline definition.
-        assert_true(all(map(lambda e: len(e["pipeline_element"].get_result("metadata")) == 2, pipeline_results)))
+        assert_true(all(map(lambda e: len(e["pipeline_element"]["result"]["metadata"]) == 2, pipeline_results)))
 
 
 def test_multiple_adder():
@@ -224,7 +231,7 @@ def test_multiple_adder():
     result = pipeline_results[0]
     assert_equal(result["status"], "ok")
     pipeline_element = result["pipeline_element"]
-    adder_results = pipeline_element.get_result("adder-data")
+    adder_results = pipeline_element["result"]["adder-data"]
     assert_equal(len(adder_results), adder_count)
     for i in range(adder_count):
-        assert_equal(adder_results[i].content, f"content from adder {i}")
+        assert_equal(adder_results[i]["content"], f"content from adder {i}")

--- a/datalad_metalad/tests/test_conduct.py
+++ b/datalad_metalad/tests/test_conduct.py
@@ -7,6 +7,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+import json
 import tempfile
 from dataclasses import dataclass
 from itertools import chain
@@ -155,6 +156,9 @@ def test_simple_pipeline():
             configuration=simple_pipeline))
 
     eq_(len(pipeline_results), 4)
+
+    # check for correct json encoding
+    assert_true(all(map(json.dumps, pipeline_results)))
 
 
 def test_extract():


### PR DESCRIPTION
This PR fixes an issue where meta-conduct puts an object into the datalad result dict. This is an error, instead a JSON-object should be put there.

- [x] json-encode pipeline before adding it to datalad result
- [x] add regression tests
