### PR TITLE
Use case insensitive comparison of labels in `meta-conduct`

### DIFF
--- a/datalad_metalad/processor/add.py
+++ b/datalad_metalad/processor/add.py
@@ -5,7 +5,10 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import (
+    cast,
+    Dict,
+)
 
 from datalad.api import meta_add
 

--- a/datalad_metalad/processor/extract.py
+++ b/datalad_metalad/processor/extract.py
@@ -26,8 +26,8 @@ logger = logging.getLogger("datalad.metadata.processor.extract")
 
 
 class ExtractorType(enum.Enum):
-    DATASET = "Dataset"
-    FILE = "File"
+    DATASET = "dataset"
+    FILE = "file"
 
 
 @dataclass
@@ -50,7 +50,7 @@ class MetadataExtractor(Processor):
                  extractor_name: str
                  ):
         super().__init__()
-        self.extractor_type = extractor_type
+        self.extractor_type = extractor_type.lower()
         self.extractor_name = extractor_name
 
     def process(self, pipeline_element: PipelineElement) -> PipelineElement:
@@ -72,14 +72,14 @@ class MetadataExtractor(Processor):
         )
         object_type = dataset_traverse_record.type
 
-        if object_type == "File":
+        if object_type == "file":
             object_path = Path(dataset_traverse_record.path)
             kwargs = dict(
                 extractorname=self.extractor_name,
                 dataset=dataset_path,
-                path=object_path.relative_to(dataset_path),
+                path=dataset_path / object_path.relative_to(dataset_path),
                 result_renderer="disabled")
-        elif object_type == "Dataset":
+        elif object_type == "dataset":
             kwargs = dict(
                 extractorname=self.extractor_name,
                 dataset=dataset_path,

--- a/datalad_metalad/provider/datasettraverse.py
+++ b/datalad_metalad/provider/datasettraverse.py
@@ -130,7 +130,7 @@ class DatasetTraverser(Provider):
                         DatasetTraverseResult(**{
                             "state": ResultState.SUCCESS,
                             "fs_base_path": self.fs_base_path,
-                            "type": "Dataset",
+                            "type": "dataset",
                             "path": element_path,
                             **self._get_dataset_result_part(dataset)
                         })
@@ -149,7 +149,7 @@ class DatasetTraverser(Provider):
                     lgr.debug(f"Ignoring excluded element {element_path}")
                     continue
 
-                if not isdir(element_path):
+                if not element_path.is_dir():
 
                     if self._already_visited(dataset, relative_element_path):
                         continue
@@ -162,7 +162,7 @@ class DatasetTraverser(Provider):
                                 DatasetTraverseResult(**{
                                     "state": ResultState.SUCCESS,
                                     "fs_base_path": self.fs_base_path,
-                                    "type": "File",
+                                    "type": "file",
                                     "path": element_path,
                                     **self._get_dataset_result_part(dataset)
                                 })


### PR DESCRIPTION
Labels such as "file", "dataset", and "both" are now compared case-insensitive.