### PR TITLE
Enable `meta-add` to add multiple records in a single call

### DIFF
--- a/datalad_metalad/add.py
+++ b/datalad_metalad/add.py
@@ -111,19 +111,19 @@ class Add(Interface):
     that describes the metadata.
 
     In case of an API-call metadata can also be provided in a python
-    dictionary directly.
+    dictionary or a list of dictionaries.
 
     [TODO: add a schema]
 
     If metadata is read from a source, parameter can overwrite or
     amend information that is stored in the source.
 
-    The METADATA and the ADDITIONAL_VALUES arguments can be pre-fixed by '@',
+    The ADDITIONAL_VALUES arguments can be pre-fixed by '@',
     in which case the pre-fixed argument is interpreted as a file-name and
     the argument value is read from the file.
 
     The metadata key "dataset-id" must be identical to the ID of the dataset
-    that receives the metadata.
+    that receives the metadata, unless -i or --allow-id-mismatch is provided.
     """
 
     _examples_ = [
@@ -151,7 +151,7 @@ class Add(Interface):
         ),
         dict(
             text='Add metadata stored in the file "metadata-123.json" to the '
-                 'dataset the current directory and overwrite the values'
+                 'dataset in the current directory and overwrite the values'
                  'from "metadata-123.json" with the values stored in '
                  '"extra-info.json"',
             code_cmd='datalad meta-add metadata-123.json @extra-info.json'

--- a/datalad_metalad/utils.py
+++ b/datalad_metalad/utils.py
@@ -271,3 +271,17 @@ def read_json_object(path_or_object: Union[str, JSONObject]) -> JSONObject:
                 metadata_file = open(path_or_object, "tr")
         return json.load(metadata_file)
     return path_or_object
+
+
+def read_json_objects(path_or_object: Union[str, JSONObject]
+                      ) -> List[JSONObject]:
+
+    if isinstance(path_or_object, str):
+        if path_or_object == "-":
+            metadata_file = sys.stdin
+        else:
+            metadata_file = open(path_or_object, "tr")
+        path_or_object = json.load(metadata_file)
+    if isinstance(path_or_object, List):
+        return path_or_object
+    return [path_or_object]


### PR DESCRIPTION
This PR enables `meta-add` to add multiple records in a single invocation or call.

Adding multiple records in a single call greatly reduces the overhead that stems from locking/unlocking the backend, writing out dataset tree version lists and uuid sets, writing out references. The number of records that can be added at once is only limited by the memory available (and, of course, the disk space).

The metadata argument is now considered to contain either a string, that identifies a JSON-file, a single metadata record, i.e. a  dictionary, or a list of metadata records If a file is given, it must also contain either a single dictionary or a list of dictionaries, where each dictionary describes a metadata record.

