### PR TITLE
Add locking tests for meta-add, fix previously existing tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -171,8 +171,8 @@ test_script:
   - sh: mkdir __testhome__
   - cd __testhome__
     # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_metalad %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_metalad ${DTS}
+  - cmd: python -m nose --traverse-namespace -v -A "not (turtle)" --with-cov --cover-package datalad_metalad %DTS%
+  - sh:  python -m nose --traverse-namespace -v -A "not (turtle)" --with-cov --cover-package datalad_metalad ${DTS}
 
 
 after_test:

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -82,7 +82,10 @@ def test_unknown_key_reporting(file_name):
         },
         open(file_name, "tw"))
 
-    with patch("datalad_metalad.add.check_dataset"):
+    with \
+            patch("datalad_metalad.add.check_dataset"), \
+            patch("datalad_metalad.add.lock_backend"):
+
         _assert_raise_mke_with_keys(
             ["strange_key_name"],
             metadata=file_name)
@@ -148,7 +151,10 @@ def test_incomplete_non_mandatory_key_handling(file_name):
         },
         open(file_name, "tw"))
 
-    with patch("datalad_metalad.add.check_dataset"):
+    with \
+            patch("datalad_metalad.add.check_dataset"), \
+            patch("datalad_metalad.add.lock_backend"):
+
         _assert_raise_mke_with_keys(
             ["root_dataset_version", "dataset_path"],
             metadata=file_name,
@@ -163,7 +169,9 @@ def test_override_key_reporting(file_name):
         },
         open(file_name, "tw"))
 
-    with patch("datalad_metalad.add.check_dataset"):
+    with \
+            patch("datalad_metalad.add.check_dataset"), \
+            patch("datalad_metalad.add.lock_backend"):
         _assert_raise_mke_with_keys(
             ["dataset_id"],
             metadata=file_name,
@@ -689,6 +697,8 @@ def check_multi_adding(metadata, file_count, metadata_count):
         )
 
         assert_result_count(res, file_count * metadata_count)
+        if file_count * metadata_count == 0:
+            return
 
         results = tuple(meta_dump(dataset=git_repo.pathobj, recursive=True))
         assert_true(len(results), file_count * metadata_count)
@@ -717,7 +727,13 @@ def _check_memory_multiple_end_to_end_test(file_count: int,
     check_multi_adding(json_objects, file_count, metadata_count)
 
 
+def test_really_large_end_to_end():
+    _check_memory_multiple_end_to_end_test(1000, 1)
+
+
 def test_add_multiple_file_records_end_to_end():
+    _check_memory_multiple_end_to_end_test(0, 0)
+    _check_memory_multiple_end_to_end_test(1, 1)
     _check_memory_multiple_end_to_end_test(31, 31)
     _check_memory_multiple_end_to_end_test(1, 1000)
     _check_memory_multiple_end_to_end_test(1000, 1)

--- a/datalad_metalad/tests/test_locking.py
+++ b/datalad_metalad/tests/test_locking.py
@@ -1,0 +1,116 @@
+import concurrent.futures
+import tempfile
+from typing import (
+    Dict,
+    List,
+    Union,
+)
+from unittest.mock import patch
+from unittest import SkipTest
+from uuid import uuid4
+
+from datalad.api import (
+    meta_add,
+    meta_dump,
+)
+from datalad.support.gitrepo import GitRepo
+from datalad.tests.utils import eq_
+
+from .utils import create_dataset
+
+
+JSONObject = Union[Dict, List]
+
+dataset_id = uuid4()
+
+
+meta_data_pattern = {
+    "type": "file",
+    "extractor_name": "ex_extractor_name",
+    "extractor_version": "ex_extractor_version",
+    "extraction_parameter": {"parameter1": "pvalue1"},
+    "extraction_time": 1111666.3333,
+    "agent_name": "test_name",
+    "agent_email": "test email",
+    "dataset_id": str(dataset_id),
+    "dataset_version": "000000111111111112012121212121",
+    "extracted_metadata": {"info": "some metadata"}
+}
+
+
+def get_metadata(index: int):
+    return {
+        **meta_data_pattern,
+        "path": f"a/b/{index}",
+        "extraction_time": 1000 + index,
+    }
+
+
+def call_meta_add(locked: bool,
+                  *args,
+                  **kwargs) -> List:
+
+    if locked:
+        return list(meta_add(*args, **kwargs))
+    else:
+        with patch("datalad_metalad.add.lock_backend"), \
+             patch("datalad_metalad.add.unlock_backend"):
+
+            return list(meta_add(*args, **kwargs))
+
+
+def perform_concurrent_adds(locked: bool,
+                            git_repo: GitRepo,
+                            count: int):
+
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        running = set([
+            executor.submit(
+                call_meta_add,
+                locked=locked,
+                metadata=get_metadata(index),
+                dataset=git_repo.path
+            )
+            for index in range(count)
+        ])
+        concurrent.futures.wait(running)
+
+
+def get_all_metadata_records(git_repo: GitRepo) -> List[JSONObject]:
+    res = meta_dump(dataset=git_repo.path, path="*", recursive=True)
+    return list(res)
+
+
+def verify_locking_adds(git_repo: GitRepo, test_process_number: int):
+    perform_concurrent_adds(True, git_repo, test_process_number)
+    metadata_records = get_all_metadata_records(git_repo)
+    eq_(len(metadata_records), test_process_number)
+
+
+def test_meta_add_locking_impact_end_to_end():
+
+    test_process_number = 100
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = create_dataset(temp_dir, dataset_id)
+
+        perform_concurrent_adds(False, git_repo, test_process_number)
+
+        metadata_records = get_all_metadata_records(git_repo)
+        if len(metadata_records) == test_process_number:
+            raise SkipTest(
+                "cannot trigger race condition, "
+                "leaving meta-add locking test")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = create_dataset(temp_dir, dataset_id)
+        verify_locking_adds(git_repo, test_process_number)
+
+
+def test_meta_add_locking_end_to_end():
+
+    test_process_number = 100
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        git_repo = create_dataset(temp_dir, dataset_id)
+        verify_locking_adds(git_repo, test_process_number)


### PR DESCRIPTION
Add tests for proper locking in meta-add and adapt previously existing tests to the changed execution path in meta-add.

Adds a test that performs meta-add concurrently and checks for proper results. Adds a second test that attempts to verify that locking meta-add invocation gives correct results if concurrent meta-add invocations lead to missing metadata entries.

Reduce verbosity of test runs by letting `nose` capture standard output

- [ ] TODO: Due to the nature of race conditions, this test has a slim chance of succeeding even with faulty code.
