### PR TITLE
Use `locked_backend()` context manager to lock the backend

### DIFF
--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -90,7 +90,7 @@ def test_unknown_key_reporting(file_name):
 
     with \
             patch("datalad_metalad.add.check_dataset"), \
-            patch("datalad_metalad.add.lock_backend"):
+            patch("datalad_metalad.add.locked_backend"):
 
         _assert_raise_mke_with_keys(
             ["strange_key_name"],
@@ -159,7 +159,7 @@ def test_incomplete_non_mandatory_key_handling(file_name):
 
     with \
             patch("datalad_metalad.add.check_dataset"), \
-            patch("datalad_metalad.add.lock_backend"):
+            patch("datalad_metalad.add.locked_backend"):
 
         _assert_raise_mke_with_keys(
             ["root_dataset_version", "dataset_path"],
@@ -177,7 +177,7 @@ def test_override_key_reporting(file_name):
 
     with \
             patch("datalad_metalad.add.check_dataset"), \
-            patch("datalad_metalad.add.lock_backend"):
+            patch("datalad_metalad.add.locked_backend"):
         _assert_raise_mke_with_keys(
             ["dataset_id"],
             metadata=file_name,

--- a/datalad_metalad/tests/test_locking.py
+++ b/datalad_metalad/tests/test_locking.py
@@ -57,9 +57,7 @@ def call_meta_add(locked: bool,
     if locked:
         return list(meta_add(*args, **kwargs))
     else:
-        with patch("datalad_metalad.add.lock_backend"), \
-             patch("datalad_metalad.add.unlock_backend"):
-
+        with patch("datalad_metalad.add.locked_backend"):
             return list(meta_add(*args, **kwargs))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ coverage
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
-datalad-metadata-model>=0.1.0rc3
+datalad-metadata-model>=0.1.0rc4


### PR DESCRIPTION
This PR uses the `lock_backend()` context manager to lock the backend. This ensures the release of locks in case of an exception.