### PR TITLE
Use `NoDatasetFound` exception in `meta-extract` if appropriate

### DIFF
--- a/datalad_metalad/exceptions.py
+++ b/datalad_metalad/exceptions.py
@@ -27,3 +27,7 @@ class MetadataKeyException(RuntimeError):
 
 class NoMetadataStoreFound(InsufficientArgumentsError):
     pass
+
+
+class ExtractorNotFoundError(InsufficientArgumentsError):
+    pass

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -60,8 +60,8 @@ from datalad.support.param import Parameter
 
 from dataladmetadatamodel.metadatapath import MetadataPath
 
+from .exceptions import ExtractorNotFoundError
 from .utils import (
-    NoDatasetFound,
     args_to_dict,
     check_dataset,
 )
@@ -227,6 +227,8 @@ class Extract(Interface):
                 if isinstance(context, str)
                 else context))
 
+        source_dataset = check_dataset(dataset or curdir, "extract metadata")
+        x = """
         try:
             source_dataset = check_dataset(dataset or curdir,
                                            "extract metadata")
@@ -240,6 +242,7 @@ class Extract(Interface):
                 logger=lgr
             )
             return
+        """
 
         source_dataset_version = context.get("dataset_version", None)
         if source_dataset_version is None:
@@ -456,7 +459,7 @@ def get_extractor_class(extractor_name: str) -> Union[
         iter_entry_points("datalad.metadata.extractors", extractor_name))
 
     if not entry_points:
-        raise ValueError(
+        raise ExtractorNotFoundError(
             "Requested metadata extractor '{}' not available".format(
                 extractor_name))
 

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 from datalad.distribution.dataset import Dataset
 from datalad.api import meta_extract
+from datalad.support.exceptions import NoDatasetFound
 from datalad.utils import chpwd
 
 from datalad.tests.utils import (
@@ -30,7 +31,9 @@ from datalad.tests.utils import (
 
 from dataladmetadatamodel.metadatapath import MetadataPath
 
+from .utils import create_dataset
 from ..extract import get_extractor_class
+from ..exceptions import ExtractorNotFoundError
 
 
 meta_tree = {
@@ -46,16 +49,17 @@ def test_empty_dataset_error(path):
     # go into virgin dir to avoid detection of any dataset
     with chpwd(path):
         assert_raises(
-            ValueError,
+            NoDatasetFound,
             meta_extract, extractorname="metalad_core")
 
 
 @with_tempfile(mkdir=True)
 def test_unknown_extractor_error(path):
     # ensure failure on unavailable metadata extractor
+    create_dataset(path, UUID(int=0))
     with chpwd(path):
         assert_raises(
-            ValueError,
+            ExtractorNotFoundError,
             meta_extract, extractorname="bogus__")
 
 


### PR DESCRIPTION
This PR fixes #218

This PR modifies the behavior of `meta-extract` to raise a `NoDatasetFound` exception if no dataset or an unusable dataset, i.e. a dataset without id, was provided as argument