### PR TITLE
Use datalad's Parameter to render pipeline help

### DIFF
--- a/datalad_metalad/conduct.py
+++ b/datalad_metalad/conduct.py
@@ -250,6 +250,7 @@ class Conduct(Interface):
             for name, class_instance in class_instances.items():
                 print(class_instance.interface_documentation.get_description(name))
                 print(class_instance.interface_documentation.get_entry_description(name))
+                print("\n")
             return
 
         constructor_keyword_args = get_constructor_keyword_args(

--- a/datalad_metalad/pipeline/documentedinterface.py
+++ b/datalad_metalad/pipeline/documentedinterface.py
@@ -6,6 +6,8 @@ from typing import (
     List,
 )
 
+from datalad.support.param import Parameter
+
 
 @dataclasses.dataclass(frozen=True)
 class ParameterEntry:
@@ -52,31 +54,32 @@ class DocumentedInterface:
 
     def get_description(self,
                         name: str) -> str:
-        return f"{name}:" + "\n".join(textwrap.wrap(self.description))
+
+        return f"-- Element: {name} --\n" \
+               + "\n".join(textwrap.wrap(self.description)) + "\n"
 
     def get_entry_description(self,
                               name: str) -> str:
-        return "\n".join(
+        return "\n\n".join(
             self._render_entry(name, entry)
             for entry in self.parameter_entries)
 
     def _render_entry(self,
                       name: str,
                       entry: ParameterEntry):
-        if entry.constraints:
-            constraints_text = "Allowed values: " + str(entry.constraints)
-        else:
-            constraints_text = ""
 
-        help_text = "\n".join(textwrap.wrap(entry.help)) + "\n"
-        return "{name}.{keyword} {optional}\n" \
-               "{description}\n" \
-               "{values}".format(
-                    name=name,
-                    keyword=entry.keyword,
-                    optional="  (optional)" if entry.optional is True else "",
-                    description=help_text,
-                    values=constraints_text)
+        dl_parameter_name = "{name}.{keyword}{optional}".format(
+            name=name,
+            keyword=entry.keyword,
+            optional=" (optional)" if entry.optional is True else "",
+        )
+
+        dl_parameter = Parameter(
+            args=("dummy",),
+            doc=entry.help,
+            constraints=entry.constraints)
+
+        return dl_parameter.get_autodoc(dl_parameter_name)
 
     def _get_missing_keys(self,
                           name: str,


### PR DESCRIPTION
Use datalad's Parameter class to improve help text rendering in pipeline help (`meta-conduct --pipeline-help`).

