### PR TITLE
Ensure that require_dataset calls check for install

### DIFF
--- a/datalad_metalad/utils.py
+++ b/datalad_metalad/utils.py
@@ -49,7 +49,7 @@ def check_dataset(dataset_or_path: Union[Dataset, str],
         dataset = require_dataset(
             dataset_or_path,
             purpose=purpose,
-            check_installed=dataset_or_path is not None)
+            check_installed=True)
 
     if not dataset.repo:
         raise NoDatasetFound(


### PR DESCRIPTION
This is a metalad-side approach to fix issue #222 

This PR ensures that `require_dataset` is always called with `check_installed=True`. That should have been the case anyway in the failing tests though. Therefore I believe that the problem might be in `require_dataset`.

