### PR TITLE
Fix relative path resolution in DatasetTraverser

### DIFF
--- a/datalad_metalad/pipeline/provider/datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/datasettraverse.py
@@ -103,7 +103,7 @@ class DatasetTraverser(Provider):
             raise ValueError(f"{item_type.lower()} is not a known item_type. "
                              f"Known types are: {', '.join(known_types)}")
 
-        self.top_level_dir = Path(top_level_dir)
+        self.top_level_dir = Path(top_level_dir).absolute()
         self.item_set = self.name_to_item_set[item_type.lower()]
         self.traverse_sub_datasets = traverse_sub_datasets
         self.root_dataset = require_dataset(self.top_level_dir,

--- a/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+from datalad.tests.utils import (
+    assert_equal,
+    with_tempfile,
+)
+
+from ....tests.utils import create_dataset_proper
+from ..datasettraverse import DatasetTraverser
+
+
+@with_tempfile(mkdir=True)
+def test_relative_top_level_dir(temp_dir: str):
+    relative_path_str = "./some/path/dataset_0"
+
+    dataset_path = Path(temp_dir) / relative_path_str
+    dataset_path.mkdir(parents=True)
+    create_dataset_proper(dataset_path)
+
+    old_path = Path.cwd()
+    os.chdir(str(temp_dir))
+    traverser = DatasetTraverser(
+        top_level_dir=relative_path_str,
+        item_type="both"
+    )
+    assert_equal(traverser.fs_base_path, dataset_path)
+
+    # prevent teardown error due to modified working directory
+    os.chdir(str(old_path))


### PR DESCRIPTION
Fixes #253 

This PR fixes issue #253, i.e. the faulty handling of a relative path in DatasetTraverser's top-level-dir arguments.
