### PR TITLE
Disable result renderer in subdataset in core extractor calls

### DIFF
--- a/datalad_metalad/extractors/core.py
+++ b/datalad_metalad/extractors/core.py
@@ -144,7 +144,8 @@ class DataladCoreExtractor(MetadataExtractor):
             }
             subdsid = ds.subdatasets(
                 contains=subds['path'],
-                return_type='item-or-list').get('gitmodule_datalad-id', None)
+                return_type='item-or-list',
+                result_renderer="disabled").get('gitmodule_datalad-id', None)
             if subdsid:
                 subdsinfo['identifier'] = 'datalad:{}'.format(subdsid)
             parts.append(subdsinfo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ coverage
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
-datalad-metadata-model>=0.3.0,<0.4.0
+datalad-metadata-model>=0.3.1,<0.4.0


### PR DESCRIPTION
Fixes #255 

This PR disables the result renderer when calling `Dataset.subdatasets()`. As a result the extractor execution will no longer yield subdataset names.
