### PR TITLE
Fix traverser-error on unresolved top_level_dir path argument

### DIFF
--- a/datalad_metalad/pipeline/provider/datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/datasettraverse.py
@@ -103,7 +103,7 @@ class DatasetTraverser(Provider):
             raise ValueError(f"{item_type.lower()} is not a known item_type. "
                              f"Known types are: {', '.join(known_types)}")
 
-        self.top_level_dir = Path(top_level_dir).absolute()
+        self.top_level_dir = Path(top_level_dir).absolute().resolve()
         self.item_set = self.name_to_item_set[item_type.lower()]
         self.traverse_sub_datasets = traverse_sub_datasets
         self.root_dataset = require_dataset(self.top_level_dir,

--- a/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
@@ -11,8 +11,9 @@ from ..datasettraverse import DatasetTraverser
 
 
 @with_tempfile(mkdir=True)
-def test_relative_top_level_dir(temp_dir: str):
+def test_relative_and_unresolved_top_level_dir(temp_dir: str):
     relative_path_str = "./some/path/dataset_0"
+    unresolved_path = "./some/path/../path/dataset_0"
 
     dataset_path = Path(temp_dir) / relative_path_str
     dataset_path.mkdir(parents=True)
@@ -20,11 +21,22 @@ def test_relative_top_level_dir(temp_dir: str):
 
     old_path = Path.cwd()
     os.chdir(str(temp_dir))
+
+    # check relative paths
     traverser = DatasetTraverser(
         top_level_dir=relative_path_str,
         item_type="both"
     )
     assert_equal(traverser.fs_base_path, dataset_path)
+
+    # check unresolved paths
+    traverser = DatasetTraverser(
+        top_level_dir=Path(temp_dir) / unresolved_path,
+        item_type="both"
+    )
+
+    tuple(traverser.next_object())
+    assert_equal(traverser.fs_base_path, dataset_path.resolve())
 
     # prevent teardown error due to modified working directory
     os.chdir(str(old_path))


### PR DESCRIPTION
Fixes #256 

This PR fixes insufficient path canonization in the DatasetTraverser constructor.
Unresolved path arguments, e.g. '/home/dataset0/../dataset0/subdataset1', are
now resolved, i.e. converted to '/home/dataset0/subdataset1'. This prevents an
error that is otherwise raised in a `Path.relative_to()`
