### PR TITLE
fix the determination of the datalad version

### DIFF
--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -121,7 +121,12 @@ def test_plainest(path):
     # Expect an exception if no dataset exists. Depending on the
     # dataset version ValueError or NoDatasetFound is raised.
     from datalad import __version__
-    major, minor, patch = tuple(map(int, __version__.split(".")))
+    major, minor, patch = tuple(
+        map(
+            lambda s: int(s.split("+")[0]),
+            __version__.split(".")[0:3]
+        )
+    )
 
     if major == 0 and minor <= 15:
         expected_exception = ValueError


### PR DESCRIPTION
This commit improves the interpretation of the `__version__` string from `datalad._version` in order to handle local version labels properly, i.e. ignore them, when determining major, minor, and patch numbers.

This fixes failing metalad-extension tests on datalad PRs.


## Changelog:

### Internal:
 - fix failing metadata-extension tests on datalad PRs
