### PR TITLE
Change argument list delimiterr from "--" to "++"

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -73,6 +73,8 @@ default_mapper_family = "git"
 
 lgr = logging.getLogger("datalad.metadata.extract")
 
+argument_delimiter = "++"
+
 
 @dataclass
 class ExtractionArguments:
@@ -197,10 +199,15 @@ class Extract(Interface):
         extractorargs=Parameter(
             args=("extractorargs",),
             metavar="EXTRACTOR_ARGUMENTS",
-            doc="""Extractor arguments given as string arguments to the
-            extractor. If dataset level extraction is performed, i.e. no path
-            is required, specify '--' as path to prevent interpretation of
-            the first extractor argument as path.""",
+            doc=f"""Extractor arguments given as string arguments to the
+            extractor. The extractor arguments are interpreted as key-value
+            pairs. The first argument is the name of the key, the next argument
+            is the value for that key, and so on. Consequently, there should be
+            an even number of extractor arguments.
+            
+            If dataset level extraction is performed, i.e. no path
+            is required, specify '{argument_delimiter}' as path to prevent
+            interpretation of the first extractor argument as path.""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()))
 
@@ -218,7 +225,7 @@ class Extract(Interface):
         # Get basic arguments
         extractor_name = extractorname
         extractor_args = extractorargs
-        path = None if path == "--" else path
+        path = None if path == argument_delimiter else path
         context = (
             {}
             if context is None

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -384,7 +384,7 @@ def test_extra_parameter_recognition(ds_path):
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
             result_renderer="disabled")
 
@@ -533,7 +533,7 @@ def test_extractor_parameter_handling(ds_path):
         meta_extract(
             extractorname="metalad_example_dataset",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k0", "v0", "k1", "v1"],
             result_renderer="disabled")
 
@@ -573,7 +573,7 @@ def test_external_extractor(ds_path):
     
     if sys.argv
     """
-    for path, extractor_name in (("--", "metalad_external_dataset"),
+    for path, extractor_name in (("++", "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
         result = meta_extract(
             extractorname=extractor_name,
@@ -601,7 +601,8 @@ def test_external_extractor_categories(ds_path):
     ds.save()
     assert_repo_status(ds.path)
 
-    for path, extractor_name in (("--", "metalad_external_dataset"), ("sub/one", "metalad_external_file")):
+    for path, extractor_name in (("++", "metalad_external_dataset"),
+                                 ("sub/one", "metalad_external_file")):
         for output_category in ("DIRECTORY", "FILE"):
             assert_raises(
                 NotImplementedError,
@@ -670,7 +671,7 @@ def test_get_required_content_called(ds_path):
         result = meta_extract(
             extractorname="test_name",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k0", "v0", "k1", "v1"],
             result_renderer="disabled")
         assert_true(


### PR DESCRIPTION
In order to provide extractor parameter to a dataset-level extraction call, metalad has to detect, that the arguments following the extractor are not a file path and potentially further extractor parameter, but extractor parameter for a dataset-level extractor. To do that, the caller has to provided a **delimiter**. This was previously `--`. But `argparse`, which is used by `datalad` swallows a `--`-argument. Therefore the delimiter was changed to `++`.