### PR TITLE
Replace positional `--`-argument with `--force-dataset-level`-flag 

### DIFF
--- a/datalad_metalad/conduct.py
+++ b/datalad_metalad/conduct.py
@@ -111,8 +111,8 @@ class Conduct(Interface):
 
     _examples_ = [
         dict(
-            text="Run 'metalad_example_dataset' extractor on the top dataset and "
-                 "all subdatasets. Add the resulting metadata in aggregated"
+            text="Run 'metalad_example_dataset' extractor on the top dataset "
+                 "and all subdatasets. Add the resulting metadata in aggregated"
                  "mode. This command uses the provided pipeline"
                  "definition 'extract_metadata'.",
             code_cmd="datalad meta-conduct extract_metadata "
@@ -173,9 +173,7 @@ class Conduct(Interface):
                    with the name of the pipeline element, followed by ".",
                    the keyname, a "=", and the value. The pipeline element
                    arguments are identified by the pattern
-                   "<name>.<key>=<value>". If an optional path has the same
-                   structure as a pipeline element argument, the pipeline 
-                   element arguments can be terminated by "++"."""),
+                   "<name>.<key>=<value>"."""),
     )
 
     @staticmethod
@@ -188,7 +186,7 @@ class Conduct(Interface):
             processing_mode: str = "process",
             pipeline_help: bool = False):
 
-        element_arguments, file_path = split_arguments(arguments, "++")
+        element_arguments = arguments
         conduct_configuration = read_json_object(configuration)
 
         elements = [

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -73,6 +73,8 @@ default_mapper_family = "git"
 
 lgr = logging.getLogger("datalad.metadata.extract")
 
+argument_delimiter = "++"
+
 
 @dataclass
 class ExtractionArguments:
@@ -197,10 +199,15 @@ class Extract(Interface):
         extractorargs=Parameter(
             args=("extractorargs",),
             metavar="EXTRACTOR_ARGUMENTS",
-            doc="""Extractor arguments given as string arguments to the
-            extractor. If dataset level extraction is performed, i.e. no path
-            is required, specify '--' as path to prevent interpretation of
-            the first extractor argument as path.""",
+            doc=f"""Extractor arguments given as string arguments to the
+            extractor. The extractor arguments are interpreted as key-value
+            pairs. The first argument is the name of the key, the next argument
+            is the value for that key, and so on. Consequently, there should be
+            an even number of extractor arguments.
+            
+            If dataset level extraction is performed, i.e. no path
+            is required, specify '{argument_delimiter}' as path to prevent
+            interpretation of the first extractor argument as path.""",
             nargs="*",
             constraints=EnsureStr() | EnsureNone()))
 
@@ -218,7 +225,7 @@ class Extract(Interface):
         # Get basic arguments
         extractor_name = extractorname
         extractor_args = extractorargs
-        path = None if path == "--" else path
+        path = None if path == argument_delimiter else path
         context = (
             {}
             if context is None

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -384,8 +384,9 @@ def test_extra_parameter_recognition(ds_path):
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
-            path="++",
-            extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
+            force_dataset_level=True,
+            path="k1",
+            extractorargs=["v1", "k2", "v2", "k3", "v3"],
             result_renderer="disabled")
 
         eq_(fe.call_count, 0)
@@ -533,8 +534,9 @@ def test_extractor_parameter_handling(ds_path):
         meta_extract(
             extractorname="metalad_example_dataset",
             dataset=ds,
-            path="++",
-            extractorargs=["k0", "v0", "k1", "v1"],
+            force_dataset_level=True,
+            path="k0",
+            extractorargs=["v0", "k1", "v1"],
             result_renderer="disabled")
 
         eq_(fe.call_count, 0)
@@ -568,12 +570,7 @@ def test_external_extractor(ds_path):
     ds.save()
     assert_repo_status(ds.path)
 
-    extractor = """
-    import sys
-    
-    if sys.argv
-    """
-    for path, extractor_name in (("++", "metalad_external_dataset"),
+    for path, extractor_name in ((None, "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
         result = meta_extract(
             extractorname=extractor_name,
@@ -601,7 +598,7 @@ def test_external_extractor_categories(ds_path):
     ds.save()
     assert_repo_status(ds.path)
 
-    for path, extractor_name in (("++", "metalad_external_dataset"),
+    for path, extractor_name in ((None, "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
         for output_category in ("DIRECTORY", "FILE"):
             assert_raises(
@@ -671,7 +668,7 @@ def test_get_required_content_called(ds_path):
         result = meta_extract(
             extractorname="test_name",
             dataset=ds,
-            path="++",
+            path=None,
             extractorargs=["k0", "v0", "k1", "v1"],
             result_renderer="disabled")
         assert_true(

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -384,7 +384,7 @@ def test_extra_parameter_recognition(ds_path):
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
             result_renderer="disabled")
 
@@ -533,7 +533,7 @@ def test_extractor_parameter_handling(ds_path):
         meta_extract(
             extractorname="metalad_example_dataset",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k0", "v0", "k1", "v1"],
             result_renderer="disabled")
 
@@ -573,7 +573,7 @@ def test_external_extractor(ds_path):
     
     if sys.argv
     """
-    for path, extractor_name in (("--", "metalad_external_dataset"),
+    for path, extractor_name in (("++", "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
         result = meta_extract(
             extractorname=extractor_name,
@@ -601,7 +601,8 @@ def test_external_extractor_categories(ds_path):
     ds.save()
     assert_repo_status(ds.path)
 
-    for path, extractor_name in (("--", "metalad_external_dataset"), ("sub/one", "metalad_external_file")):
+    for path, extractor_name in (("++", "metalad_external_dataset"),
+                                 ("sub/one", "metalad_external_file")):
         for output_category in ("DIRECTORY", "FILE"):
             assert_raises(
                 NotImplementedError,
@@ -670,7 +671,7 @@ def test_get_required_content_called(ds_path):
         result = meta_extract(
             extractorname="test_name",
             dataset=ds,
-            path="--",
+            path="++",
             extractorargs=["k0", "v0", "k1", "v1"],
             result_renderer="disabled")
         assert_true(

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -8,6 +8,7 @@ sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
 datalad-metadata-model>=0.3.0,<0.4.0
+pytest
 
 # required for extractor tests
 Pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
 test_requires =
     nose
     coverage
+    pytest
 packages = find:
 include_package_data = True
 

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -237,7 +237,7 @@ def get_dataset_level_extract_cmdline(dataset_path: Path,
         "-d", str(dataset_path),
         arguments.dataset_extractor,
     ] + (
-        ["++"] + metalad_arguments
+        ["--force-dataset-level"] + metalad_arguments
         if metalad_arguments
         else [])
 


### PR DESCRIPTION
In order to provide extractor parameter to a dataset-level extraction call, metalad has to detect, that the arguments following the extractor are not a file path and potentially further extractor parameter, but extractor parameter for a dataset-level extractor. To do that, the caller has to provide a **delimiter**. This was previously `--`. But `argparse`, which is used by `datalad` swallows a `--`-argument.

Therefore the flag `--force-dataset-level` is added to indicate that the arguments following the extractor name are only extractor arguments and not a path, and that a dataset-level extraction is requested.

This PR basically replaces PR #262 