### PR TITLE
Improve tests, fix potential errors and reduce log output

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -183,8 +183,8 @@ test_script:
   - sh: mkdir __testhome__
   - cd __testhome__
     # run test selection
-  - cmd: python -m nose -v --with-cov --cover-package datalad_metalad ..\%DTS%
-  - sh:  python -m nose -v --with-cov --cover-package datalad_metalad ../${DTS}
+  - cmd: python -m nose --traverse-namespace -v --with-cov --cover-package datalad_metalad ..\%DTS%
+  - sh:  python -m nose --traverse-namespace -v --with-cov --cover-package datalad_metalad ../${DTS}
 
 
 after_test:

--- a/datalad_metalad/extractors/tests/test_annex.py
+++ b/datalad_metalad/extractors/tests/test_annex.py
@@ -33,7 +33,7 @@ def test_annex_contentmeta(path):
     mfile_path.parent.mkdir()
     mfile_path.write_text(u'nothing')
     (ds.pathobj / 'ignored').write_text(u'nometa')
-    ds.save()
+    ds.save(result_renderer="disabled")
     ds.repo.set_metadata(
         text_type(mfile_path.relative_to(ds.pathobj)),
         init={'tag': 'mytag', 'fancy': 'this?'}

--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -42,7 +42,7 @@ from ...tests.utils import create_dataset_proper
 @with_tree(tree={'file.dat': ''})
 def check_api(annex, path):
     ds = Dataset(path).create(force=True, annex=annex)
-    ds.save()
+    ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
 
     processed_extractors, skipped_extractors = [], []

--- a/datalad_metalad/extractors/tests/test_custom.py
+++ b/datalad_metalad/extractors/tests/test_custom.py
@@ -94,7 +94,7 @@ def test_custom_dsmeta(path):
     sample_jsonld_.update({'@id': ds.id})
     # enable custom extractor
     # use default location
-    ds.save()
+    ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
     res = ds.meta_extract(extractorname='metalad_custom')
     assert_status('ok', res)
@@ -108,7 +108,7 @@ def test_custom_dsmeta(path):
         'datalad.metadata.custom-dataset-source',
         'nothere',
         where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
         on_failure='ignore',
@@ -128,7 +128,7 @@ def test_custom_dsmeta(path):
         # always POSIX!
         'down/customloc',
         where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
         on_failure='ignore',
@@ -142,7 +142,7 @@ def test_custom_dsmeta(path):
         # put back default
         '.metadata/dataset.json',
         where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
         on_failure='ignore',
@@ -169,7 +169,7 @@ def test_custom_contentmeta(path):
     ds.config.add('datalad.metadata.custom-content-source',
                   '{freldir}/_{fname}.dl.json',
                   where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
         path="sub/one",
@@ -203,7 +203,7 @@ def test_custom_contentmeta(path):
     })
 def test_custom_content_broken(path):
     ds = Dataset(path).create(force=True)
-    ds.save()
+    ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
         path='sub/one',

--- a/datalad_metalad/extractors/tests/test_runprov.py
+++ b/datalad_metalad/extractors/tests/test_runprov.py
@@ -32,7 +32,7 @@ def test_custom_dsmeta(path):
     ds.config.add('datalad.metadata.nativetype',
                   'metalad_runprov',
                   where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
     # run when there are no run records
     res = ds.meta_extract(extractorname='metalad_runprov')

--- a/datalad_metalad/metadatatypes/tests/test_metadata.py
+++ b/datalad_metalad/metadatatypes/tests/test_metadata.py
@@ -43,9 +43,8 @@ def test_basic():
         path=MetadataPath("d1/file_1.txt")
     )
 
-    print(md)
-    print(md.as_json_obj())
-    print(md.as_json_str())
+    md.as_json_obj()
+    md.as_json_str()
 
 
 def test_uuid_conversion():
@@ -63,11 +62,9 @@ def test_uuid_conversion():
         path=MetadataPath("d1/file_1.txt")
     )
 
-    print(md)
-    print(md.as_json_obj())
-    print(md.as_json_str())
+    md.as_json_obj()
+    md.as_json_str()
 
 
 def test_from_json():
     md = MetadataRecord.from_json(test_json_1)
-    print(md)

--- a/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from datalad.tests.utils import (
     assert_equal,
+    chpwd,
     with_tempfile,
 )
 
@@ -19,24 +20,19 @@ def test_relative_and_unresolved_top_level_dir(temp_dir: str):
     dataset_path.mkdir(parents=True)
     create_dataset_proper(dataset_path)
 
-    old_path = Path.cwd()
-    os.chdir(str(temp_dir))
+    with chpwd(str(temp_dir)):
+        # check relative paths
+        traverser = DatasetTraverser(
+            top_level_dir=relative_path_str,
+            item_type="both"
+        )
+        assert_equal(traverser.fs_base_path, dataset_path)
 
-    # check relative paths
-    traverser = DatasetTraverser(
-        top_level_dir=relative_path_str,
-        item_type="both"
-    )
-    assert_equal(traverser.fs_base_path, dataset_path)
+        # check unresolved paths
+        traverser = DatasetTraverser(
+            top_level_dir=Path(temp_dir) / unresolved_path,
+            item_type="both"
+        )
 
-    # check unresolved paths
-    traverser = DatasetTraverser(
-        top_level_dir=Path(temp_dir) / unresolved_path,
-        item_type="both"
-    )
-
-    tuple(traverser.next_object())
-    assert_equal(traverser.fs_base_path, dataset_path.resolve())
-
-    # prevent teardown error due to modified working directory
-    os.chdir(str(old_path))
+        tuple(traverser.next_object())
+        assert_equal(traverser.fs_base_path, dataset_path.resolve())

--- a/datalad_metalad/tests/__init__.py
+++ b/datalad_metalad/tests/__init__.py
@@ -16,12 +16,12 @@ def make_ds_hierarchy_with_metadata(path):
     """
     ds = Dataset(path).create(force=True)
     create_tree(ds.path, {'file.dat': 'content'})
-    ds.save()
+    ds.save(result_renderer="disabled")
     ds.repo.set_metadata('file.dat', reset={'tag': ['one', 'two']})
     subds = ds.create('sub')
     # we need one real piece of content for metadata extraction
     (subds.pathobj / 'real').write_text(text_type('real'))
-    ds.save(recursive=True)
+    ds.save(recursive=True, result_renderer="disabled")
     return ds, subds
 
 

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -38,6 +38,7 @@ from datalad.tests.utils import (
     assert_raises,
     assert_result_count,
     assert_true,
+    chpwd,
     eq_,
     known_failure_windows,
     with_tempfile,
@@ -607,15 +608,11 @@ def test_current_dir_add_end_to_end(file_name):
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = create_dataset(temp_dir, default_id)
 
-        execute_directory = Path.cwd()
-        os.chdir(git_repo.pathobj)
-
-        res = meta_add(metadata=file_name)
-        assert_result_count(res, 1)
-        assert_result_count(res, 1, type='dataset')
-        assert_result_count(res, 0, type='file')
-
-        os.chdir(execute_directory)
+        with chpwd(git_repo.pathobj):
+            res = meta_add(metadata=file_name)
+            assert_result_count(res, 1)
+            assert_result_count(res, 1, type='dataset')
+            assert_result_count(res, 0, type='file')
 
         results = tuple(meta_dump(dataset=git_repo.pathobj,
                                   recursive=True,

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -113,7 +113,8 @@ def test_unknown_key_reporting(file_name):
 
         _assert_raise_mke_with_keys(
             ["strange_key_name"],
-            metadata=file_name)
+            metadata=file_name,
+            result_renderer="disabled")
 
 
 @with_tempfile
@@ -136,7 +137,8 @@ def test_unknown_key_allowed(file_name):
         meta_add(
             metadata=file_name,
             dataset=git_repo.path,
-            allow_unknown=True)
+            allow_unknown=True,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 0)
         assert_true(dp.call_count == 1)
@@ -162,7 +164,8 @@ def test_optional_keys(file_name):
         meta_add(
             metadata=file_name,
             dataset=git_repo.path,
-            allow_unknown=True)
+            allow_unknown=True,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 1)
         assert_true(dp.call_count == 0)
@@ -183,7 +186,8 @@ def test_incomplete_non_mandatory_key_handling(file_name):
         _assert_raise_mke_with_keys(
             ["root_dataset_version"],
             metadata=file_name,
-            additionalvalues=json.dumps({"root_dataset_id": 1}))
+            additionalvalues=json.dumps({"root_dataset_id": 1}),
+            result_renderer="disabled")
 
 
 @with_tempfile
@@ -201,7 +205,8 @@ def test_override_key_reporting(file_name):
             ["dataset_id"],
             metadata=file_name,
             additionalvalues=json.dumps(
-                {"dataset_id": "a2010203-1011-2021-3031-404142434445"}))
+                {"dataset_id": "a2010203-1011-2021-3031-404142434445"}),
+            result_renderer="disabled")
 
 
 def test_object_parameter():
@@ -218,7 +223,8 @@ def test_object_parameter():
                 "type": "file",
                 "path": "d1/d1.1./f1.1.1"
             },
-            dataset=git_repo.path)
+            dataset=git_repo.path,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 1)
         assert_true(dp.call_count == 0)
@@ -240,7 +246,8 @@ def test_additional_values_object_parameter():
             additionalvalues={
                 "path": "d1/d1.1./f1.1.1"
             },
-            dataset=git_repo.path)
+            dataset=git_repo.path,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 1)
         assert_true(dp.call_count == 0)
@@ -295,7 +302,8 @@ def test_id_mismatch_allowed(file_name):
                 {"dataset_id": "a1010203-1011-2021-3031-404142434445"}),
             dataset=git_repo.path,
             allow_override=True,
-            allow_id_mismatch=True)
+            allow_id_mismatch=True,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 0)
         assert_true(dp.call_count == 1)
@@ -358,7 +366,8 @@ def test_root_id_mismatch_allowed(file_name):
                 }),
             dataset=git_repo.path,
             allow_override=True,
-            allow_id_mismatch=True)
+            allow_id_mismatch=True,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 0)
         assert_true(dp.call_count == 1)
@@ -384,7 +393,8 @@ def test_override_key_allowed(file_name):
             additionalvalues=json.dumps(
                 {"dataset_id": str(default_id)}),
             allow_override=True,
-            dataset=git_repo.path)
+            dataset=git_repo.path,
+            result_renderer="disabled")
 
         assert_true(fp.call_count == 0)
         assert_true(dp.call_count == 1)
@@ -396,7 +406,6 @@ def _get_top_nodes(git_repo,
                    dataset_tree_path=""):
 
     # Ensure that metadata was created
-    print("asdasdasd")
     tree_version_list, uuid_set, mrr = \
         get_top_nodes_and_metadata_root_record(
             mapper_family="git",
@@ -444,7 +453,10 @@ def test_add_dataset_end_to_end(file_name):
 
         git_repo = create_dataset(temp_dir, default_id)
 
-        res = meta_add(metadata=file_name, dataset=git_repo.path)
+        res = meta_add(
+            metadata=file_name,
+            dataset=git_repo.path,
+            result_renderer="disabled")
         assert_result_count(res, 1)
         assert_result_count(res, 1, type='dataset')
         assert_result_count(res, 0, type='file')
@@ -474,7 +486,10 @@ def test_add_file_end_to_end(file_name):
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = create_dataset(temp_dir, default_id)
 
-        res = meta_add(metadata=file_name, dataset=git_repo.path)
+        res = meta_add(
+            metadata=file_name,
+            dataset=git_repo.path,
+            result_renderer="disabled")
         assert_result_count(res, 1)
         assert_result_count(res, 1, type='file')
         assert_result_count(res, 0, type='dataset')
@@ -510,7 +525,10 @@ def test_subdataset_add_dataset_end_to_end(file_name):
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = create_dataset(temp_dir, default_id)
 
-        res = meta_add(metadata=file_name, dataset=git_repo.path)
+        res = meta_add(
+            metadata=file_name,
+            dataset=git_repo.path,
+            result_renderer="disabled")
         assert_result_count(res, 1)
         assert_result_count(res, 1, type='dataset')
         assert_result_count(res, 0, type='file')
@@ -558,7 +576,10 @@ def test_subdataset_add_file_end_to_end(file_name):
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = create_dataset(temp_dir, default_id)
 
-        res = meta_add(metadata=file_name, dataset=git_repo.path)
+        res = meta_add(
+            metadata=file_name,
+            dataset=git_repo.path,
+            result_renderer="disabled")
         assert_result_count(res, 1)
         assert_result_count(res, 1, type='file')
         assert_result_count(res, 0, type='dataset')
@@ -609,7 +630,7 @@ def test_current_dir_add_end_to_end(file_name):
         git_repo = create_dataset(temp_dir, default_id)
 
         with chpwd(git_repo.pathobj):
-            res = meta_add(metadata=file_name)
+            res = meta_add(metadata=file_name, result_renderer="disabled")
             assert_result_count(res, 1)
             assert_result_count(res, 1, type='dataset')
             assert_result_count(res, 0, type='file')
@@ -659,12 +680,16 @@ def test_add_file_dump_end_to_end(file_name):
         import time
 
         start_time = time.time()
-        res = meta_add(metadata=[], dataset=git_repo.path)
-        print(f"meta-add x 0: {time.time() - start_time} s")
+        res = meta_add(
+            metadata=[],
+            dataset=git_repo.path,
+            result_renderer="disabled")
 
         start_time = time.time()
-        res = meta_add(metadata=file_name, dataset=git_repo.path)
-        print(f"meta-add x 1: {time.time() - start_time} s")
+        res = meta_add(
+            metadata=file_name,
+            dataset=git_repo.path,
+            result_renderer="disabled")
 
         assert_result_count(res, 1)
         assert_result_count(res, 1, type='file')
@@ -734,14 +759,21 @@ def check_multi_adding(metadata: Union[str, List],
                     patch("datalad_metalad.add.sys") as sys_mock:
 
                 stdin_mock.return_value = iter(metadata)
-                meta_add(metadata="-", dataset=git_repo.path, batch_mode=True)
+                meta_add(
+                    metadata="-",
+                    dataset=git_repo.path,
+                    batch_mode=True,
+                    result_renderer="disabled")
                 assert_in(
                     call.stdout.write(
                         f'{{"status": "ok", "succeeded": '
                         f'{file_count * metadata_count}, "failed": 0}}\n'),
                     sys_mock.mock_calls)
         else:
-            res = meta_add(metadata=metadata, dataset=git_repo.path)
+            res = meta_add(
+                metadata=metadata,
+                dataset=git_repo.path,
+                result_renderer="disabled")
             assert_result_count(res, file_count * metadata_count)
 
         print(
@@ -826,7 +858,8 @@ def test_cache_age(temp_dir: str):
             metadata="-",
             dataset=temp_dir,
             allow_id_mismatch=True,
-            batch_mode=True)
+            batch_mode=True,
+            result_renderer="disabled")
 
         assert_true(fc.call_count >= 2)
 
@@ -845,7 +878,8 @@ def test_batch_mode(temp_dir: str):
             metadata="-",
             dataset=temp_dir,
             allow_id_mismatch=True,
-            batch_mode=True)
+            batch_mode=True,
+            result_renderer="disabled")
 
         assert_in(
             call.stdout.write(
@@ -907,7 +941,8 @@ def test_add_regression_1(temp_dir: str):
     for json_object in json_objects:
         for result in meta_add(dataset=temp_dir,
                                metadata=json_object,
-                               allow_id_mismatch=True):
+                               allow_id_mismatch=True,
+                               result_renderer="disabled"):
             eq_(result["status"], "ok")
 
     results = list(meta_dump(dataset=temp_dir, path="", recursive=True))
@@ -928,12 +963,13 @@ def test_multi_add_regression_1(temp_dir: str):
     ]
     for result in meta_add(dataset=temp_dir,
                            metadata=json_objects,
-                           allow_id_mismatch=True):
+                           allow_id_mismatch=True,
+                           result_renderer="disabled"):
         eq_(result["status"], "ok")
 
     results = list(meta_dump(dataset=temp_dir, path="*", recursive=True))
     for result in results:
-        print(result["metadata"])
+        assert_in("metadata", result)
     assert_equal(len(results), len(json_objects))
     for result in results:
         eq_(result["status"], "ok")
@@ -953,7 +989,8 @@ def test_multi_add_regression_2(temp_dir: str):
         for result in meta_add(dataset=temp_dir,
                                metadata=json_input.name,
                                json_lines=True,
-                               allow_id_mismatch=True):
+                               allow_id_mismatch=True,
+                               result_renderer="disabled"):
             eq_(result["status"], "ok")
 
         results = list(meta_dump(dataset=temp_dir, path="", recursive=True))

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -58,6 +58,17 @@ meta_tree = {
 }
 
 
+def _create_dataset_at_path(ds_path):
+    ds = Dataset(ds_path).create(force=True)
+    ds.config.add(
+        'datalad.metadata.exclude-path',
+        '.metadata',
+        where='dataset')
+    ds.save(result_renderer="disabled")
+    assert_repo_status(ds.path)
+    return ds
+
+
 @with_tempfile(mkdir=True)
 def test_empty_dataset_error(path):
     # go into virgin dir to avoid detection of any dataset
@@ -97,15 +108,9 @@ def _check_metadata_record(metadata_record: dict,
 
 
 @with_tree(meta_tree)
-def test_dataset_extraction_result(path):
+def test_dataset_extraction_result(ds_path):
 
-    ds = Dataset(path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     extractor_name = "metalad_example_dataset"
     extractor_class = get_extractor_class(extractor_name)
@@ -138,13 +143,7 @@ def test_dataset_extraction_result(path):
 @with_tree(meta_tree)
 def test_file_extraction_result(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     file_path = "sub/one"
     extractor_name = "metalad_example_file"
@@ -182,13 +181,7 @@ def test_file_extraction_result(ds_path):
 @with_tree(meta_tree)
 def test_legacy1_dataset_extraction_result(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     extractor_name = "metalad_core"
     extractor_version = "1"
@@ -219,13 +212,7 @@ def test_legacy1_dataset_extraction_result(ds_path):
 @with_tree(meta_tree)
 def test_legacy2_dataset_extraction_result(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     extractor_name = "datalad_core"
     extractor_version = "un-versioned"
@@ -254,13 +241,7 @@ def test_legacy2_dataset_extraction_result(ds_path):
 @with_tree(meta_tree)
 def test_legacy1_file_extraction_result(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     file_path = "sub/one"
     extractor_name = "metalad_core"
@@ -294,13 +275,7 @@ def test_legacy1_file_extraction_result(ds_path):
 @with_tree(meta_tree)
 def test_legacy2_file_extraction_result(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     file_path = "sub/one"
     extractor_name = "datalad_core"
@@ -332,13 +307,7 @@ def test_legacy2_file_extraction_result(ds_path):
 @with_tree(meta_tree)
 def test_path_parameter_directory(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     assert_raises(
         ValueError,
@@ -351,13 +320,7 @@ def test_path_parameter_directory(ds_path):
 @with_tree(meta_tree)
 def test_path_parameter_recognition(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -374,13 +337,7 @@ def test_path_parameter_recognition(ds_path):
 @with_tree(meta_tree)
 def test_extra_parameter_recognition(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -407,13 +364,7 @@ def test_extra_parameter_recognition(ds_path):
 @with_tree(meta_tree)
 def test_path_and_extra_parameter_recognition(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -439,13 +390,7 @@ def test_path_and_extra_parameter_recognition(ds_path):
 @with_tree(meta_tree)
 def test_context_dict_parameter_handling(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -465,13 +410,7 @@ def test_context_dict_parameter_handling(ds_path):
 @with_tree(meta_tree)
 def test_context_str_parameter_handling(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -491,13 +430,7 @@ def test_context_str_parameter_handling(ds_path):
 @with_tree(meta_tree)
 def test_get_context(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     result = tuple(
         meta_extract(
@@ -524,13 +457,7 @@ def test_get_context(ds_path):
 @with_tree(meta_tree)
 def test_extractor_parameter_handling(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     with patch("datalad_metalad.extract.do_file_extraction") as fe, \
          patch("datalad_metalad.extract.do_dataset_extraction") as de:
@@ -566,13 +493,7 @@ def test_extractor_parameter_handling(ds_path):
 @with_tree(meta_tree)
 def test_external_extractor(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     for path, extractor_name in ((None, "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
@@ -594,13 +515,7 @@ def test_external_extractor(ds_path):
 @with_tree(meta_tree)
 def test_external_extractor_categories(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     for path, extractor_name in ((None, "metalad_external_dataset"),
                                  ("sub/one", "metalad_external_file")):
@@ -621,13 +536,7 @@ def test_external_extractor_categories(ds_path):
 @with_tree(meta_tree)
 def test_get_required_content_called(ds_path):
 
-    ds = Dataset(ds_path).create(force=True)
-    ds.config.add(
-        'datalad.metadata.exclude-path',
-        '.metadata',
-        where='dataset')
-    ds.save()
-    assert_repo_status(ds.path)
+    ds = _create_dataset_at_path(ds_path)
 
     class TestExtractor(DatasetMetadataExtractor):
         def __init__(self, dataset, ref_commit, parameter):
@@ -706,7 +615,7 @@ def test_path_assembly(temp_dir):
     file_name = "info.txt"
     file_path = subdir_path / file_name
     file_path.write_text("some content")
-    ds.save()
+    ds.save(result_renderer="disabled")
 
     with chpwd(str(subdir_path)):
         with patch("datalad_metalad.extract.do_file_extraction") as dfe_mock:
@@ -723,7 +632,7 @@ def test_not_tracked_error_catching(temp_dir):
     file_name = "info.txt"
     file_path = ds.pathobj / file_name
     file_path.write_text("some content")
-    ds.save()
+    ds.save(result_renderer="disabled")
 
     assert_raises(
         ValueError,

--- a/datalad_metalad/tests/test_locking.py
+++ b/datalad_metalad/tests/test_locking.py
@@ -68,6 +68,7 @@ def perform_concurrent_adds(locked: bool,
                 locked=locked,
                 metadata=get_metadata(index),
                 dataset=git_repo.path,
+                result_renderer="disabled"
             )
             for index in range(count)
         ])
@@ -125,8 +126,14 @@ def test_multiple_adds():
     # overwrite old records
     with tempfile.TemporaryDirectory() as temp_dir:
         git_repo = create_dataset(temp_dir, dataset_id)
-        meta_add(dataset=git_repo.path, metadata=get_metadata(0))
-        meta_add(dataset=git_repo.path, metadata=get_metadata(1))
+        meta_add(
+            dataset=git_repo.path,
+            metadata=get_metadata(0),
+            result_renderer="disabled")
+        meta_add(
+            dataset=git_repo.path,
+            metadata=get_metadata(1),
+            result_renderer="disabled")
         metadata_records = get_all_metadata_records(git_repo)
         eq_(len(metadata_records), 2)
         metadata = [mr["metadata"] for mr in metadata_records]

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -111,7 +111,8 @@ def add_dataset_level_metadata(metadata_store: Path,
             **base_elements,
             "type": "dataset"
         },
-        dataset=metadata_store)
+        dataset=metadata_store,
+        result_renderer="disabled")
 
 
 def add_file_level_metadata(metadata_store: Path,
@@ -136,4 +137,5 @@ def add_file_level_metadata(metadata_store: Path,
             "type": "file",
             "path": str(file_path)
         },
-        dataset=metadata_store)
+        dataset=metadata_store,
+        result_renderer="disabled")

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -43,7 +43,7 @@ def create_dataset_proper(directory: Union[str, Path],
         'datalad.metadata.exclude-path',
         '.metadata',
         where='dataset')
-    ds.save()
+    ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
 
     sub_dataset_names = sub_dataset_names or []


### PR DESCRIPTION
This PR fixes potential tests errors by replacing `os.chdir()` with the `datalad.tests.utils.chpwd()` context handler.

In addition it disables the result renderer for test-internal datalad-api calls.
