### PR TITLE
Fix symlink issue

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -183,8 +183,8 @@ test_script:
   - sh: mkdir __testhome__
   - cd __testhome__
     # run test selection
-  - cmd: python -m nose --traverse-namespace -v --with-cov --cover-package datalad_metalad ..\%DTS%
-  - sh:  python -m nose --traverse-namespace -v --with-cov --cover-package datalad_metalad ../${DTS}
+  - cmd: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad ..\%DTS%
+  - sh: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad ../${DTS}
 
 
 after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -164,6 +164,7 @@ install:
 
 
 build_script:
+  - python -m pip install --upgrade pip
   - python -m pip install -r requirements-devel.txt
   - python -m pip install .
 

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-devel.txt
+        pip install .
     - name: Build docs
       run: |
         make -C docs html doctest;

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -648,7 +648,7 @@ def legacy_extract_dataset(ea: ExtractionArguments) -> Iterable[dict]:
 
     if issubclass(ea.extractor_class, MetadataExtractor):
 
-        status = ea.source_dataset.repo.get_submodules()
+        status = ea.source_dataset.subdatasets()
         extractor = ea.extractor_class()
         ensure_legacy_content_availability(ea, extractor, "dataset", status)
 

--- a/datalad_metalad/extractors/custom.py
+++ b/datalad_metalad/extractors/custom.py
@@ -28,7 +28,7 @@ from datalad.log import log_progress
 from datalad.support.json_py import load as jsonload
 from datalad.dochelpers import exc_str
 from datalad.utils import (
-    assure_list,
+    ensure_list,
     Path,
     PurePosixPath,
 )
@@ -132,7 +132,7 @@ def _get_dsmeta_srcfiles(ds):
     cfg_srcfiles = ds.config.obtain(
         'datalad.metadata.custom-dataset-source',
         [])
-    cfg_srcfiles = assure_list(cfg_srcfiles)
+    cfg_srcfiles = ensure_list(cfg_srcfiles)
     # OK to be always POSIX
     srcfiles = ['.metadata/dataset.json'] \
         if not cfg_srcfiles and op.lexists(

--- a/datalad_metalad/extractors/tests/test_annex.py
+++ b/datalad_metalad/extractors/tests/test_annex.py
@@ -11,13 +11,7 @@
 from six import text_type
 
 from datalad.distribution.dataset import Dataset
-# API commands needed
-from datalad.api import (
-    create,
-    save,
-    meta_extract,
-)
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     assert_result_count,
     known_failure_windows,

--- a/datalad_metalad/extractors/tests/test_annex.py
+++ b/datalad_metalad/extractors/tests/test_annex.py
@@ -27,7 +27,7 @@ from datalad.tests.utils import (
 
 @known_failure_windows
 @with_tempfile
-def test_annex_contentmeta(path):
+def test_annex_contentmeta(path=None):
     ds = Dataset(path).create()
     mfile_path = ds.pathobj / 'sudir' / 'dummy.txt'
     mfile_path.parent.mkdir()

--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -20,7 +20,7 @@ from datalad.api import (
 )
 from datalad.support.gitrepo import GitRepo
 from datalad.support.exceptions import NoDatasetFound
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_true,
     assert_not_in,

--- a/datalad_metalad/extractors/tests/test_custom.py
+++ b/datalad_metalad/extractors/tests/test_custom.py
@@ -11,7 +11,7 @@
 from six import text_type
 
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_repo_status,
     assert_result_count,
     assert_status,

--- a/datalad_metalad/extractors/tests/test_custom.py
+++ b/datalad_metalad/extractors/tests/test_custom.py
@@ -88,7 +88,7 @@ testmeta = {
             'dataset.json': jsondumps(sample_jsonld)},
         'down': {
             'customloc': jsondumps(testmeta)}})
-def test_custom_dsmeta(path):
+def test_custom_dsmeta(path=None):
     ds = Dataset(path).create(force=True)
     sample_jsonld_ = dict(sample_jsonld)
     sample_jsonld_.update({'@id': ds.id})
@@ -107,7 +107,7 @@ def test_custom_dsmeta(path):
     ds.config.add(
         'datalad.metadata.custom-dataset-source',
         'nothere',
-        where='dataset')
+        scope='branch')
     ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
@@ -127,7 +127,7 @@ def test_custom_dsmeta(path):
         'datalad.metadata.custom-dataset-source',
         # always POSIX!
         'down/customloc',
-        where='dataset')
+        scope='branch')
     ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
@@ -141,7 +141,7 @@ def test_custom_dsmeta(path):
         'datalad.metadata.custom-dataset-source',
         # put back default
         '.metadata/dataset.json',
-        where='dataset')
+        scope='branch')
     ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
@@ -163,12 +163,12 @@ def test_custom_dsmeta(path):
             '_one.dl.json': '{"some":"thing"}',
         }
     })
-def test_custom_contentmeta(path):
+def test_custom_contentmeta(path=None):
     ds = Dataset(path).create(force=True)
     # use custom location
     ds.config.add('datalad.metadata.custom-content-source',
                   '{freldir}/_{fname}.dl.json',
-                  where='dataset')
+                  scope='branch')
     ds.save(result_renderer="disabled")
     res = ds.meta_extract(
         extractorname='metalad_custom',
@@ -201,7 +201,7 @@ def test_custom_contentmeta(path):
             'one': '1',
         }
     })
-def test_custom_content_broken(path):
+def test_custom_content_broken(path=None):
     ds = Dataset(path).create(force=True)
     ds.save(result_renderer="disabled")
     res = ds.meta_extract(

--- a/datalad_metalad/extractors/tests/test_runprov.py
+++ b/datalad_metalad/extractors/tests/test_runprov.py
@@ -11,7 +11,7 @@
 from six import text_type
 
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in,
     assert_not_in,
     assert_repo_status,

--- a/datalad_metalad/extractors/tests/test_runprov.py
+++ b/datalad_metalad/extractors/tests/test_runprov.py
@@ -25,13 +25,13 @@ from datalad.tests.utils import (
 
 @known_failure_windows
 @with_tree({'existing_file': 'some_content'})
-def test_custom_dsmeta(path):
+def test_custom_dsmeta(path=None):
     ds = Dataset(path).create(force=True)
     # enable custom extractor
     # use default location
     ds.config.add('datalad.metadata.nativetype',
                   'metalad_runprov',
-                  where='dataset')
+                  scope='branch')
     ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
     # run when there are no run records

--- a/datalad_metalad/extractors/tests/test_studyminimeta.py
+++ b/datalad_metalad/extractors/tests/test_studyminimeta.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from datalad.api import meta_extract
 from datalad.distribution.dataset import Dataset
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     with_tempfile,
     with_tree
 )

--- a/datalad_metalad/extractors/tests/test_studyminimeta.py
+++ b/datalad_metalad/extractors/tests/test_studyminimeta.py
@@ -506,7 +506,7 @@ study:
 
 @mock.patch("datalad.distribution.dataset.Dataset")
 @with_tree({".studyminimeta.yaml": proper_yaml_1})
-def test_successful_yaml_parsing(dataset_mock, directory_path: str):
+def test_successful_yaml_parsing(dataset_mock=None, directory_path=None):
 
     dataset_mock.configure_mock(**{
         "pathobj": Path(directory_path),
@@ -524,7 +524,7 @@ def test_successful_yaml_parsing(dataset_mock, directory_path: str):
 
 @mock.patch("datalad.distribution.dataset.Dataset")
 @with_tree({"some_dir": {"somefile.yaml": proper_yaml_1}})
-def test_config_honouring(dataset_mock, directory_path: str):
+def test_config_honouring(dataset_mock=None, directory_path=None):
 
     dataset_mock.configure_mock(**{
         "pathobj": Path(directory_path),
@@ -542,7 +542,7 @@ def test_config_honouring(dataset_mock, directory_path: str):
 
 @mock.patch("datalad.distribution.dataset.Dataset")
 @with_tree({".studyminimeta.yaml": error_yaml_1})
-def test_unsuccessful_yaml_parsing(dataset_mock, directory_path: str):
+def test_unsuccessful_yaml_parsing(dataset_mock=None, directory_path=None):
 
     dataset_mock.configure_mock(**{
         "pathobj": Path(directory_path),
@@ -562,7 +562,7 @@ def test_unsuccessful_yaml_parsing(dataset_mock, directory_path: str):
 
 @mock.patch("datalad.distribution.dataset.Dataset")
 @with_tree({'.studyminimeta.yaml': error_yaml_2})
-def test_schema_violation(dataset_mock, directory_path: str):
+def test_schema_violation(dataset_mock=None, directory_path=None):
 
     dataset_mock.configure_mock(**{
         "pathobj": Path(directory_path),
@@ -581,7 +581,7 @@ def test_schema_violation(dataset_mock, directory_path: str):
 
 @mock.patch("datalad.distribution.dataset.Dataset")
 @with_tree({"some_file.yaml": error_yaml_1})
-def test_file_handling(dataset_mock, directory_path: str):
+def test_file_handling(dataset_mock=None, directory_path=None):
 
     dataset_mock.configure_mock(**{
         "pathobj": Path(directory_path),

--- a/datalad_metalad/indexers/tests/test_jsonld.py
+++ b/datalad_metalad/indexers/tests/test_jsonld.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import eq_
+from datalad.tests.utils_pytest import eq_
 
 from .common import MOCKED_STUDYMINIMETA_JSONLD
 from ..jsonld import JsonLdIndexer

--- a/datalad_metalad/indexers/tests/test_studyminimeta.py
+++ b/datalad_metalad/indexers/tests/test_studyminimeta.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import eq_
+from datalad.tests.utils_pytest import eq_
 
 from .common import MOCKED_STUDYMINIMETA_JSONLD
 from ..studyminimeta import STUDYMINIMETA_FORMAT_NAME, StudyMiniMetaIndexer

--- a/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional
 
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     chpwd,
     with_tempfile,

--- a/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
+++ b/datalad_metalad/pipeline/provider/tests/test_datasettraverse.py
@@ -1,5 +1,5 @@
-import os
 from pathlib import Path
+from typing import Optional
 
 from datalad.tests.utils import (
     assert_equal,
@@ -12,7 +12,7 @@ from ..datasettraverse import DatasetTraverser
 
 
 @with_tempfile(mkdir=True)
-def test_relative_and_unresolved_top_level_dir(temp_dir: str):
+def test_relative_and_unresolved_top_level_dir(temp_dir: Optional[str] = None):
     relative_path_str = "./some/path/dataset_0"
     unresolved_path = "./some/path/../path/dataset_0"
 

--- a/datalad_metalad/pipeline/provider/tests/test_metadatatraverser.py
+++ b/datalad_metalad/pipeline/provider/tests/test_metadatatraverser.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from datalad.tests.utils import assert_equal
+from datalad.tests.utils_pytest import assert_equal
 
 from ..metadatatraverse import (
     MetadataTraverseResult,

--- a/datalad_metalad/tests/__init__.py
+++ b/datalad_metalad/tests/__init__.py
@@ -3,7 +3,7 @@ from datalad.api import (
     Dataset,
     save,
 )
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     create_tree,
 )
 

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -98,7 +98,7 @@ def _assert_raise_mke_with_keys(exception_keys: List[str],
 
 
 @with_tempfile
-def test_unknown_key_reporting(file_name):
+def test_unknown_key_reporting(file_name=None):
 
     json.dump({
             **metadata_template,
@@ -118,7 +118,7 @@ def test_unknown_key_reporting(file_name):
 
 
 @with_tempfile
-def test_unknown_key_allowed(file_name):
+def test_unknown_key_allowed(file_name=None):
 
     json.dump({
             **metadata_template,
@@ -145,7 +145,7 @@ def test_unknown_key_allowed(file_name):
 
 
 @with_tempfile
-def test_optional_keys(file_name):
+def test_optional_keys(file_name=None):
 
     json.dump({
             **metadata_template,
@@ -172,7 +172,7 @@ def test_optional_keys(file_name):
 
 
 @with_tempfile
-def test_incomplete_non_mandatory_key_handling(file_name):
+def test_incomplete_non_mandatory_key_handling(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -191,7 +191,7 @@ def test_incomplete_non_mandatory_key_handling(file_name):
 
 
 @with_tempfile
-def test_override_key_reporting(file_name):
+def test_override_key_reporting(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -254,7 +254,7 @@ def test_additional_values_object_parameter():
 
 
 @with_tempfile
-def test_id_mismatch_detection(file_name):
+def test_id_mismatch_detection(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -282,7 +282,7 @@ def test_id_mismatch_detection(file_name):
 
 
 @with_tempfile
-def test_id_mismatch_allowed(file_name):
+def test_id_mismatch_allowed(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -310,7 +310,7 @@ def test_id_mismatch_allowed(file_name):
 
 
 @with_tempfile
-def test_root_id_mismatch_detection(file_name):
+def test_root_id_mismatch_detection(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -342,7 +342,7 @@ def test_root_id_mismatch_detection(file_name):
 
 
 @with_tempfile
-def test_root_id_mismatch_allowed(file_name):
+def test_root_id_mismatch_allowed(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -374,7 +374,7 @@ def test_root_id_mismatch_allowed(file_name):
 
 
 @with_tempfile
-def test_override_key_allowed(file_name):
+def test_override_key_allowed(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -442,7 +442,7 @@ def _get_metadata_content(metadata):
 
 
 @with_tempfile
-def test_add_dataset_end_to_end(file_name):
+def test_add_dataset_end_to_end(file_name=None):
     json.dump({
             **metadata_template,
             "type": "dataset"
@@ -473,7 +473,7 @@ def test_add_dataset_end_to_end(file_name):
 
 
 @with_tempfile
-def test_add_file_end_to_end(file_name):
+def test_add_file_end_to_end(file_name=None):
 
     test_path = "d_0/d_0.0/f_0.0.0"
 
@@ -510,7 +510,7 @@ def test_add_file_end_to_end(file_name):
 
 
 @with_tempfile
-def test_subdataset_add_dataset_end_to_end(file_name):
+def test_subdataset_add_dataset_end_to_end(file_name=None):
 
     json.dump({
             **{
@@ -559,7 +559,7 @@ def test_subdataset_add_dataset_end_to_end(file_name):
 
 
 @with_tempfile
-def test_subdataset_add_file_end_to_end(file_name):
+def test_subdataset_add_file_end_to_end(file_name=None):
 
     test_path = "d_1/d_1.0/f_1.0.0"
 
@@ -614,7 +614,7 @@ def test_subdataset_add_file_end_to_end(file_name):
 
 
 @with_tempfile
-def test_current_dir_add_end_to_end(file_name):
+def test_current_dir_add_end_to_end(file_name=None):
 
     json.dump({
             **{
@@ -660,7 +660,7 @@ def test_current_dir_add_end_to_end(file_name):
 
 
 @with_tempfile
-def test_add_file_dump_end_to_end(file_name):
+def test_add_file_dump_end_to_end(file_name=None):
 
     test_path = "d_1/d_1.0/f_1.0.0"
 
@@ -832,12 +832,12 @@ def test_add_multiple_file_records_end_to_end():
 
 
 @with_tempfile
-def test_add_multiple_metadata_records_end_to_end(file_name: str):
+def test_add_multiple_metadata_records_end_to_end(file_name=None):
     _check_file_multiple_end_to_end_test(1, 1000, file_name)
 
 
 @with_tempfile(mkdir=True)
-def test_cache_age(temp_dir: str):
+def test_cache_age(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     def slow_feed():
@@ -865,7 +865,7 @@ def test_cache_age(temp_dir: str):
 
 
 @with_tempfile(mkdir=True)
-def test_batch_mode(temp_dir: str):
+def test_batch_mode(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     json_objects = _create_json_metadata_records(file_count=3, metadata_count=3)
@@ -889,7 +889,7 @@ def test_batch_mode(temp_dir: str):
 
 
 @with_tempfile(mkdir=True)
-def test_batch_mode_end_to_end(temp_dir: str):
+def test_batch_mode_end_to_end(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     json_objects = _create_json_metadata_records(file_count=3, metadata_count=3)
@@ -931,7 +931,7 @@ critical_lines_json = \
 
 
 @with_tempfile(mkdir=True)
-def test_add_regression_1(temp_dir: str):
+def test_add_regression_1(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     json_objects = [
@@ -954,7 +954,7 @@ def test_add_regression_1(temp_dir: str):
 
 
 @with_tempfile(mkdir=True)
-def test_multi_add_regression_1(temp_dir: str):
+def test_multi_add_regression_1(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     json_objects = [
@@ -979,7 +979,7 @@ def test_multi_add_regression_1(temp_dir: str):
 
 @known_failure_windows
 @with_tempfile(mkdir=True)
-def test_multi_add_regression_2(temp_dir: str):
+def test_multi_add_regression_2(temp_dir=None):
     create_dataset_proper(temp_dir)
 
     with tempfile.NamedTemporaryFile(mode="tw") as json_input:

--- a/datalad_metalad/tests/test_add.py
+++ b/datalad_metalad/tests/test_add.py
@@ -29,7 +29,7 @@ from datalad.api import (
 )
 from datalad.cmd import BatchedCommand
 from datalad.support.exceptions import IncompleteResultsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_dict_equal,
     assert_equal,
     assert_in,

--- a/datalad_metalad/tests/test_aggregate.py
+++ b/datalad_metalad/tests/test_aggregate.py
@@ -20,7 +20,7 @@ from datalad.api import (
     meta_dump,
 )
 from datalad.support.exceptions import InsufficientArgumentsError
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_not_in,
     assert_raises,
     assert_result_count,

--- a/datalad_metalad/tests/test_conduct.py
+++ b/datalad_metalad/tests/test_conduct.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Dict
 
 from datalad.api import meta_conduct
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_equal,
     assert_true,
     eq_,

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -8,7 +8,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test metadata extraction"""
-import os
 import subprocess
 import unittest.mock
 from pathlib import Path
@@ -20,11 +19,12 @@ from typing import (
 from unittest.mock import patch
 from uuid import UUID
 
+from datalad.api import (
+    create,
+    meta_extract,
+)
 from datalad.distribution.dataset import Dataset
-from datalad.api import meta_extract
 from datalad.support.exceptions import NoDatasetFound
-from datalad.utils import chpwd
-
 from datalad.tests.utils import (
     assert_cwd_unchanged,
     assert_in,
@@ -37,7 +37,7 @@ from datalad.tests.utils import (
     with_tempfile,
     with_tree
 )
-
+from datalad.utils import chpwd
 from dataladmetadatamodel.metadatapath import MetadataPath
 
 from .utils import create_dataset
@@ -51,11 +51,13 @@ from ..extractors.base import (
 
 
 meta_tree = {
-    'sub': {
-        'one': '1',
-        'nothing': '2',
+    "sub": {
+        "one": "1",
+        "nothing": "2",
     },
 }
+
+common_kwargs = dict(result_renderer="disabled")
 
 
 def _create_dataset_at_path(ds_path):
@@ -64,28 +66,30 @@ def _create_dataset_at_path(ds_path):
         'datalad.metadata.exclude-path',
         '.metadata',
         where='dataset')
-    ds.save(result_renderer="disabled")
+    ds.save(**common_kwargs)
     assert_repo_status(ds.path)
     return ds
 
 
 @with_tempfile(mkdir=True)
-def test_empty_dataset_error(path):
+def test_empty_dataset_error(path=None):
     # go into virgin dir to avoid detection of any dataset
     with chpwd(path):
         assert_raises(
             NoDatasetFound,
-            meta_extract, extractorname="metalad_core")
+            meta_extract,
+            extractorname="metalad_core")
 
 
 @with_tempfile(mkdir=True)
-def test_unknown_extractor_error(path):
+def test_unknown_extractor_error(path=None):
     # ensure failure on unavailable metadata extractor
     create_dataset(path, UUID(int=0))
     with chpwd(path):
         assert_raises(
             ExtractorNotFoundError,
-            meta_extract, extractorname="bogus__")
+            meta_extract,
+            extractorname="bogus__")
 
 
 def _check_metadata_record(metadata_record: dict,
@@ -108,7 +112,7 @@ def _check_metadata_record(metadata_record: dict,
 
 
 @with_tree(meta_tree)
-def test_dataset_extraction_result(ds_path):
+def test_dataset_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -119,7 +123,7 @@ def test_dataset_extraction_result(ds_path):
     res = meta_extract(
         extractorname=extractor_name,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='dataset')
@@ -141,7 +145,7 @@ def test_dataset_extraction_result(ds_path):
 
 
 @with_tree(meta_tree)
-def test_file_extraction_result(ds_path):
+def test_file_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -154,7 +158,7 @@ def test_file_extraction_result(ds_path):
         extractorname=extractor_name,
         path=file_path,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='file')
@@ -179,7 +183,7 @@ def test_file_extraction_result(ds_path):
 
 
 @with_tree(meta_tree)
-def test_legacy1_dataset_extraction_result(ds_path):
+def test_legacy1_dataset_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -189,7 +193,7 @@ def test_legacy1_dataset_extraction_result(ds_path):
     res = meta_extract(
         extractorname=extractor_name,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='dataset')
@@ -210,7 +214,7 @@ def test_legacy1_dataset_extraction_result(ds_path):
 
 
 @with_tree(meta_tree)
-def test_legacy2_dataset_extraction_result(ds_path):
+def test_legacy2_dataset_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -220,7 +224,7 @@ def test_legacy2_dataset_extraction_result(ds_path):
     res = meta_extract(
         extractorname=extractor_name,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='dataset')
@@ -239,7 +243,7 @@ def test_legacy2_dataset_extraction_result(ds_path):
 
 
 @with_tree(meta_tree)
-def test_legacy1_file_extraction_result(ds_path):
+def test_legacy1_file_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -251,7 +255,7 @@ def test_legacy1_file_extraction_result(ds_path):
         extractorname=extractor_name,
         path=file_path,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='file')
@@ -273,7 +277,7 @@ def test_legacy1_file_extraction_result(ds_path):
 
 @known_failure_windows
 @with_tree(meta_tree)
-def test_legacy2_file_extraction_result(ds_path):
+def test_legacy2_file_extraction_result(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -285,7 +289,7 @@ def test_legacy2_file_extraction_result(ds_path):
         extractorname=extractor_name,
         path=file_path,
         dataset=ds,
-        result_renderer="disabled")
+        **common_kwargs)
 
     assert_result_count(res, 1)
     assert_result_count(res, 1, type='file')
@@ -305,7 +309,7 @@ def test_legacy2_file_extraction_result(ds_path):
 
 
 @with_tree(meta_tree)
-def test_path_parameter_directory(ds_path):
+def test_path_parameter_directory(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -318,7 +322,7 @@ def test_path_parameter_directory(ds_path):
 
 
 @with_tree(meta_tree)
-def test_path_parameter_recognition(ds_path):
+def test_path_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -329,13 +333,13 @@ def test_path_parameter_recognition(ds_path):
             extractorname="metalad_example_file",
             dataset=ds,
             path="sub/one",
-            result_renderer="disabled")
+            **common_kwargs)
         eq_(fe.call_count, 1)
         eq_(de.call_count, 0)
 
 
 @with_tree(meta_tree)
-def test_extra_parameter_recognition(ds_path):
+def test_extra_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -348,7 +352,7 @@ def test_extra_parameter_recognition(ds_path):
             force_dataset_level=True,
             path="k1",
             extractorargs=["v1", "k2", "v2", "k3", "v3"],
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(fe.call_count, 0)
         eq_(de.call_count, 1)
@@ -362,7 +366,7 @@ def test_extra_parameter_recognition(ds_path):
 
 
 @with_tree(meta_tree)
-def test_path_and_extra_parameter_recognition(ds_path):
+def test_path_and_extra_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -374,7 +378,7 @@ def test_path_and_extra_parameter_recognition(ds_path):
             dataset=ds,
             path="sub/one",
             extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(de.call_count, 0)
         eq_(fe.call_count, 1)
@@ -388,7 +392,7 @@ def test_path_and_extra_parameter_recognition(ds_path):
 
 
 @with_tree(meta_tree)
-def test_context_dict_parameter_handling(ds_path):
+def test_context_dict_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -400,7 +404,7 @@ def test_context_dict_parameter_handling(ds_path):
             dataset=ds,
             context={"dataset_version": "xyz"},
             path="sub/one",
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(fe.call_count, 1)
         eq_(fe.call_args[0][0].source_dataset_version, "xyz")
@@ -408,7 +412,7 @@ def test_context_dict_parameter_handling(ds_path):
 
 
 @with_tree(meta_tree)
-def test_context_str_parameter_handling(ds_path):
+def test_context_str_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -420,7 +424,7 @@ def test_context_str_parameter_handling(ds_path):
             dataset=ds,
             context='{"dataset_version": "rst"}',
             path="sub/one",
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(fe.call_count, 1)
         eq_(fe.call_args[0][0].source_dataset_version, "rst")
@@ -428,7 +432,7 @@ def test_context_str_parameter_handling(ds_path):
 
 
 @with_tree(meta_tree)
-def test_get_context(ds_path):
+def test_get_context(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -438,7 +442,7 @@ def test_get_context(ds_path):
             dataset=ds,
             get_context=True,
             path="sub/one",
-            result_renderer="disabled"))
+            **common_kwargs))
 
     version = subprocess.run(
         [
@@ -455,7 +459,7 @@ def test_get_context(ds_path):
 
 
 @with_tree(meta_tree)
-def test_extractor_parameter_handling(ds_path):
+def test_extractor_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -468,7 +472,7 @@ def test_extractor_parameter_handling(ds_path):
             force_dataset_level=True,
             path="k0",
             extractorargs=["v0", "k1", "v1"],
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(fe.call_count, 0)
         eq_(de.call_count, 1)
@@ -482,7 +486,7 @@ def test_extractor_parameter_handling(ds_path):
             dataset=ds,
             path="sub/one",
             extractorargs=["k0", "v0", "k1", "v1"],
-            result_renderer="disabled")
+            **common_kwargs)
 
         eq_(de.call_count, 0)
         eq_(fe.call_count, 1)
@@ -491,7 +495,7 @@ def test_extractor_parameter_handling(ds_path):
 
 
 @with_tree(meta_tree)
-def test_external_extractor(ds_path):
+def test_external_extractor(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -506,14 +510,14 @@ def test_external_extractor(ds_path):
                 "command", ["python", "-c", "print('True')"],
                 "arguments", ["-c", "print('True')"]
             ],
-            result_renderer="disabled")
+            **common_kwargs)
         eq_(len(result), 1)
         eq_(result[0]["status"], "ok")
         eq_(result[0]["metadata_record"]["extracted_metadata"], "True")
 
 
 @with_tree(meta_tree)
-def test_external_extractor_categories(ds_path):
+def test_external_extractor_categories(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -530,11 +534,11 @@ def test_external_extractor_categories(ds_path):
                     "data-output-category", output_category,
                     "command", ["python", "-c", "print('True')"]
                 ],
-                result_renderer="disabled")
+                **common_kwargs)
 
 
 @with_tree(meta_tree)
-def test_get_required_content_called(ds_path):
+def test_get_required_content_called(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
@@ -583,7 +587,7 @@ def test_get_required_content_called(ds_path):
             dataset=ds,
             path=None,
             extractorargs=["k0", "v0", "k1", "v1"],
-            result_renderer="disabled")
+            **common_kwargs)
         assert_true(
             result[0]
             ["metadata_record"]
@@ -614,7 +618,7 @@ def test_path_assembly(temp_dir):
     file_name = "info.txt"
     file_path = subdir_path / file_name
     file_path.write_text("some content")
-    ds.save(result_renderer="disabled")
+    ds.save(**common_kwargs)
 
     with chpwd(str(subdir_path)):
         with patch("datalad_metalad.extract.do_file_extraction") as dfe_mock:
@@ -631,7 +635,7 @@ def test_not_tracked_error_catching(temp_dir):
     file_name = "info.txt"
     file_path = ds.pathobj / file_name
     file_path.write_text("some content")
-    ds.save(result_renderer="disabled")
+    ds.save(**common_kwargs)
 
     assert_raises(
         ValueError,
@@ -639,4 +643,28 @@ def test_not_tracked_error_catching(temp_dir):
         dataset=ds,
         extractorname="metalad_core",
         path="no_such_file.txt"
+    )
+
+
+@with_tempfile(mkdir=True)
+def test_symlink_handling(tmp_dir_path_str=None):
+    tmp_dir = Path(tmp_dir_path_str)
+
+    super_ds = create(tmp_dir / "super")
+    super_ds.save(**common_kwargs)
+    create(
+        dataset=str(tmp_dir / "super"),
+        path=str(tmp_dir / "super" / "sub"),
+    )
+    super_ds.save(recursive=True, **common_kwargs)
+
+    (tmp_dir / "tmp").mkdir()
+    (tmp_dir / "tmp" / "link").symlink_to(tmp_dir / "super")
+
+    result = tuple(
+        meta_extract(
+            dataset=str(tmp_dir / "tmp" / "link"),
+            extractorname="metalad_core",
+            **common_kwargs,
+        )
     )

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -25,7 +25,7 @@ from datalad.api import (
 )
 from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import NoDatasetFound
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_cwd_unchanged,
     assert_in,
     assert_repo_status,

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -65,7 +65,7 @@ def _create_dataset_at_path(ds_path):
     ds.config.add(
         'datalad.metadata.exclude-path',
         '.metadata',
-        where='dataset')
+        scope='branch')
     ds.save(**common_kwargs)
     assert_repo_status(ds.path)
     return ds
@@ -597,7 +597,7 @@ def test_get_required_content_called(ds_path=None):
 
 @with_tempfile(mkdir=True)
 @assert_cwd_unchanged()# ok_to_chdir=True)
-def test_path_assembly(temp_dir):
+def test_path_assembly(temp_dir=None):
 
     def check_with_file_path(dfe_mock: type(unittest.mock.MagicMock),
                              file_path: Path,
@@ -628,7 +628,7 @@ def test_path_assembly(temp_dir):
 
 
 @with_tempfile(mkdir=True)
-def test_not_tracked_error_catching(temp_dir):
+def test_not_tracked_error_catching(temp_dir=None):
     # expect a value error, if the provided file is not tracked.
     ds_path = Path(temp_dir) / "dataset"
     ds = Dataset(ds_path).create()

--- a/datalad_metalad/tests/test_filter.py
+++ b/datalad_metalad/tests/test_filter.py
@@ -42,7 +42,7 @@ meta_tree = {
 
 
 @with_tempfile(mkdir=True)
-def test_empty_dataset_filter_error(path):
+def test_empty_dataset_filter_error(path=None):
     # Change into virgin dir to avoid detection of any dataset
     with chpwd(path):
         assert_raises(
@@ -53,7 +53,7 @@ def test_empty_dataset_filter_error(path):
 
 
 @with_tempfile(mkdir=True)
-def test_unknown_filter_error(path):
+def test_unknown_filter_error(path=None):
     # Ensure failure on unavailable metadata filter
     with chpwd(path):
         assert_raises(

--- a/datalad_metalad/tests/test_filter.py
+++ b/datalad_metalad/tests/test_filter.py
@@ -7,30 +7,16 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""Test metadata extraction"""
-import subprocess
-from uuid import UUID
-from typing import Optional
+"""Test filters"""
 from unittest.mock import patch
 
-from datalad.distribution.dataset import Dataset
 from datalad.api import meta_filter
 from datalad.utils import chpwd
 
-from datalad.tests.utils import (
-    assert_repo_status,
+from datalad.tests.utils_pytest import (
     assert_raises,
-    assert_result_count,
-    assert_in,
-    eq_,
-    known_failure_windows,
     with_tempfile,
-    with_tree
 )
-
-from dataladmetadatamodel.metadatapath import MetadataPath
-
-from ..extract import get_extractor_class
 
 
 meta_tree = {

--- a/datalad_metalad/tests/test_locking.py
+++ b/datalad_metalad/tests/test_locking.py
@@ -11,7 +11,7 @@ from datalad.api import (
     meta_dump,
 )
 from datalad.support.gitrepo import GitRepo
-from datalad.tests.utils import (
+from datalad.tests.utils_pytest import (
     assert_in,
     eq_,
     skip_if,

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -12,7 +12,7 @@ from datalad.api import (
 )
 from datalad.distribution.dataset import Dataset
 from datalad.support.gitrepo import GitRepo
-from datalad.tests.utils import assert_repo_status
+from datalad.tests.utils_pytest import assert_repo_status
 
 from dataladmetadatamodel.metadatapath import MetadataPath
 

--- a/datalad_metalad/tests/utils.py
+++ b/datalad_metalad/tests/utils.py
@@ -42,7 +42,7 @@ def create_dataset_proper(directory: Union[str, Path],
     ds.config.add(
         'datalad.metadata.exclude-path',
         '.metadata',
-        where='dataset')
+        scope='branch')
     ds.save(result_renderer="disabled")
     assert_repo_status(ds.path)
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,14 +1,12 @@
-.
-
 six
 datalad>=0.15.6
-nose
 coverage
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
 datalad-metadata-model>=0.3.0,<0.4.0
 pytest
+pytest-cov
 
 # required for extractor tests
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-.
-
 six
 datalad>=0.15.6
-nose
-coverage
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ install_requires =
     datalad-metadata-model >=0.3.0,<0.4.0
     pyyaml
 test_requires =
-    nose
     coverage
     pytest
+    pytest-cov
 packages = find:
 include_package_data = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,85 @@
+[tox]
+envlist = py3
+#,flake8
+
+[testenv:py3]
+changedir = __testhome__
+commands = pytest -c ../tox.ini -v {posargs} --pyargs datalad_metalad
+extras = full
+# tox 2. introduced isolation from invocation environment
+# HOME is used by annex standalone atm
+# https://git-annex.branchable.com/bugs/standalone_builds_shouldn__39__t_pollute___126____47__.ssh_with_helpers_merely_upon_annex_init/
+# so let's pass it, though in the future we should isolate
+# it back to guarantee that the tests do not rely on anything in
+# current user HOME
+passenv=HOME
+setenv=
+    DATALAD_LOG_LEVEL=DEBUG
+
+[testenv:lint]
+skip_install = true
+deps =
+    codespell~=2.0
+commands =
+    codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad setup.py
+
+[testenv:flake8]
+commands = flake8 {posargs}
+
+[testenv:venv]
+commands = {posargs}
+
+[pytest]
+filterwarnings =
+    error::DeprecationWarning:^datalad
+    error:.*yield tests:pytest.PytestCollectionWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
+    # comes from boto
+    ignore:the imp module is deprecated
+    # workaround for https://github.com/datalad/datalad/issues/6307
+    ignore:The distutils package is deprecated
+markers =
+    fail_slow
+    githubci_osx
+    githubci_win
+    integration
+    known_failure
+    known_failure_githubci_osx
+    known_failure_githubci_win
+    known_failure_osx
+    known_failure_windows
+    network
+    osx
+    probe_known_failure
+    serve_path_via_http
+    skip_if_adjusted_branch
+    skip_if_no_network
+    skip_if_on_windows
+    skip_if_root
+    skip_known_failure
+    skip_nomultiplex_ssh
+    skip_ssh
+    skip_wo_symlink_capability
+    slow
+    turtle
+    usecase
+    windows
+    with_config
+    with_fake_cookies_db
+    with_memory_keyring
+    with_sameas_remotes
+    with_testrepos
+    without_http_proxy
+# Ensure that assertion helpers in utils_pytest.py get rewritten by pytest:
+python_files = test_*.py *_test.py utils_pytest.py
+
+[flake8]
+#show-source = True
+# E265 = comment blocks like @{ section, which it can't handle
+# E266 = too many leading '#' for block comment
+# E731 = do not assign a lambda expression, use a def
+# W293 = Blank line contains whitespace
+#ignore = E265,W293,E266,E731
+max-line-length = 120
+include = datalad
+exclude = .tox,.venv,venv-debug,build,dist,doc,git/ext/


### PR DESCRIPTION
This PR fixes issue [datalad-catalog #172] (https://github.com/datalad/datalad-catalog/issues/172)

The problem was intermixing of functions that preserve symlinks, i.e. `Dataset`-functions and functions that resolve symlinks, i.e. `GitRepo`-functions.

