### PR TITLE
Fix file-path determination if dataset-path or file-path contain symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.4.2 (Thu Jul 28 2022)
+
+### Bug Fix
+
+- Fix handling of dataset or file paths with symlinks  ([@christian-monch](https://github.com/christian-monch))
+
+### Authors: 1
+
+- Christian Mönch ([@christian-monch](https://github.com/christian-monch))
+
+
 # 0.4.1 (Tue Jul 26 2022)
 
 ### Bug Fix


### PR DESCRIPTION
This PR changes two path-related calculations

1. The calculation of a relative file-path from
   an absolute file-path now takes in account,
   that the path might contain a symlink

2. The determination of the file-status now
   bases the file path on the resolved dataset
   path, if the dataset path contains a symlink