### PR TITLE
Fix JSON output of `meta-extract`, which is scrambled by status-messages from `subdatasets()`-calls

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -657,7 +657,7 @@ def legacy_extract_dataset(ea: ExtractionArguments) -> Iterable[dict]:
 
     if issubclass(ea.extractor_class, MetadataExtractor):
 
-        status = ea.source_dataset.subdatasets()
+        status = ea.source_dataset.subdatasets(result_renderer="disabled")
         extractor = ea.extractor_class()
         ensure_legacy_content_availability(ea, extractor, "dataset", status)
 

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -8,6 +8,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test metadata extraction"""
+import json
 import subprocess
 import unittest.mock
 from pathlib import Path
@@ -668,3 +669,30 @@ def test_symlink_handling(tmp_dir_path_str=None):
             **common_kwargs,
         )
     )
+
+
+@with_tempfile(mkdir=True)
+def test_submodule_status_suppression(tmp_dir_path_str=None):
+    tmp_dir = Path(tmp_dir_path_str)
+
+    super_ds = create(tmp_dir / "super")
+    super_ds.save(**common_kwargs)
+    create(
+        dataset=str(tmp_dir / "super"),
+        path=str(tmp_dir / "super" / "sub"),
+    )
+    super_ds.save(recursive=True, **common_kwargs)
+
+    output = subprocess.run(
+        [
+            "datalad",
+            "meta-extract",
+            "-d",
+            str(tmp_dir / "super"),
+            "metalad_core"
+        ],
+        stdout=subprocess.PIPE
+    ).stdout.decode().strip()
+
+    # Ensure that only JSON is written out
+    json_object = json.loads(output)


### PR DESCRIPTION
This PR fixes issue #277, where a call to `subatasets()` during `meta-extract` did not contain the keyword-arguments `result_renderer=disabled` and the status output from the `subdatasets()`-call scrambled the JSON output result.

- [x] add a regression test