### PR TITLE
Fix number of required path arguments in meta-aggregate interface

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,6 +52,12 @@ shallow_clone: false
 # Do not build a branch, if a PR with the branch exists
 skip_branch_with_pr: true
 
+# Outside of PRs, build only these branches:
+branches:
+  only:
+    - master
+    - maint_0.4
+
 
 environment:
   # Do not use `image` as a matrix dimension, to have fine-grained control over

--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -160,7 +160,7 @@ class Aggregate(Interface):
             doc=r"""
             PATH to a sub-dataset whose metadata shall be aggregated into
             the topmost dataset (ROOT_DATASET)""",
-            nargs="*",
+            nargs="+",
             constraints=EnsureStr() | EnsureNone()))
 
     @staticmethod


### PR DESCRIPTION
This PR sets the number of required path arguments in `meta-aggregate` to "one or more". This leads to proper usage- and help-messages and fixes #275.

In addition, this PR adds constraints on the branches that are tested by default in appveyor. Now only `master` and `maint_0.4` are tested if pushed to. This prevents duplicate test runs for issue-branches with a PR. Note: you have to have a PR to test an issue branch in appveyor now.
