### PR TITLE
Improve `meta-aggregate` argument handling

### DIFF
--- a/datalad_metalad/aggregate.py
+++ b/datalad_metalad/aggregate.py
@@ -156,10 +156,13 @@ class Aggregate(Interface):
             constraints=EnsureDataset() | EnsureNone()),
         path=Parameter(
             args=("path",),
-            metavar="PATH",
+            metavar="SUB_DATASET_PATH",
             doc=r"""
-            PATH to a sub-dataset whose metadata shall be aggregated into
-            the topmost dataset (ROOT_DATASET)""",
+            SUB_DATASET_PATH is a path to a sub-dataset whose metadata shall be
+            aggregated into the topmost dataset (ROOT_DATASET). The sub-dataset
+            must be located within the directory of the topmost dataset. Note:
+            if SUB_DATASET_PATH is relative, it is resolved against the current
+            working directory, not against the path of the topmost dataset""",
             nargs="+",
             constraints=EnsureStr() | EnsureNone()))
 
@@ -249,7 +252,11 @@ def process_path_spec(root_dataset: Dataset,
 
     result = []
     for path in paths:
-        sub_dataset = check_dataset(path, "meta_aggregate")
+        path_object = Path(path).absolute()
+        if path_object == root_dataset.pathobj:
+            raise ValueError(
+                f"Cannot aggregate {path_object} into itself")
+        sub_dataset = check_dataset(str(path_object), "meta_aggregate")
         result.append((
             MetadataPath(sub_dataset.pathobj.relative_to(root_dataset.pathobj)),
             sub_dataset.pathobj))

--- a/datalad_metalad/utils.py
+++ b/datalad_metalad/utils.py
@@ -2,6 +2,7 @@ import json
 import pkg_resources
 import sys
 from itertools import islice
+from pathlib import Path
 from typing import Dict, List, Union
 
 from datalad.distribution.dataset import (
@@ -57,7 +58,7 @@ def check_dataset(dataset_or_path: Union[Dataset, str],
             if ve.args and ve.args[0].startswith("No installed dataset found "):
                 raise NoDatasetFound(
                     "No valid datalad dataset found at: "
-                    f"{dataset_or_path}")
+                    f"{Path(dataset_or_path).absolute()}")
             else:
                 raise
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -4,7 +4,7 @@ coverage
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
-datalad-metadata-model>=0.3.0,<0.4.0
+datalad-metadata-model>=0.3.5,<0.4.0
 pytest
 pytest-cov
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ datalad>=0.15.6
 sphinx>=1.7.8
 sphinx-rtd-theme
 pyyaml
-datalad-metadata-model>=0.3.1,<0.4.0
+datalad-metadata-model>=0.3.5,<0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ python_requires = >= 3.5
 install_requires =
     six
     datalad >=0.15.6
-    datalad-metadata-model >=0.3.0,<0.4.0
+    datalad-metadata-model >=0.3.5,<0.4.0
     pyyaml
 test_requires =
     coverage


### PR DESCRIPTION
This PR improves the description of the arguments that have to be provided to `meta-aggregate`. It also adds a check to detect the error condition that an aggregation of metadata onto itself is requested.

This PR also updates the minimal required version of `datalad-metadata-model` to `0.3.5`. This fixes problems with spaces in file names