### PR TITLE
Fix dependencies

### DIFF
--- a/datalad_metalad/__init__.py
+++ b/datalad_metalad/__init__.py
@@ -2,8 +2,6 @@
 import os
 import hashlib
 
-from datalad.support.digests import Digester
-
 
 __docformat__ = 'restructuredtext'
 
@@ -82,6 +80,8 @@ def get_file_id(rec):
     DataLad-recognized ID. This prefix is defined in the main JSON-LD
     context defintion.
     """
+    from datalad.support.digests import Digester
+
     id_ = rec['key'] if 'key' in rec else 'SHA1-s{}--{}'.format(
         rec['bytesize'] if 'bytesize' in rec
         else 0 if rec['type'] == 'symlink'

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -488,8 +488,29 @@ def get_extractor_class(extractor_name: str) -> Union[
     """ Get an extractor from its name """
     from pkg_resources import iter_entry_points
 
-    entry_points = list(
-        iter_entry_points("datalad.metadata.extractors", extractor_name))
+    # The extractor class names of the old datalad-contained extractors have
+    # been changed, when the extractors were moved to datalad_metalad.
+    # Therefore, we have to use to extractors in
+    # `datalad_metalad.extractors.legacy` instead of any old extractor code
+    # from datalad core.
+    entry_points = [
+        entry_point
+        for entry_point in iter_entry_points(
+            "datalad.metadata.extractors",
+            extractor_name
+        )
+        if entry_point.dist.project_name != "datalad"
+    ]
+
+    if not entry_points:
+        entry_points = [
+            entry_point
+            for entry_point in iter_entry_points(
+                "datalad.metadata.extractors",
+                extractor_name
+            )
+            if entry_point.dist.project_name == "datalad"
+        ]
 
     if not entry_points:
         raise ExtractorNotFoundError(

--- a/datalad_metalad/extractors/legacy/tests/test_audio.py
+++ b/datalad_metalad/extractors/legacy/tests/test_audio.py
@@ -12,11 +12,8 @@ from pathlib import Path
 
 from datalad.tests.utils_pytest import (
     SkipTest,
-    assert_in,
-    assert_not_in,
     assert_repo_status,
     assert_result_count,
-    assert_status,
     eq_,
     with_tempfile,
 )
@@ -29,6 +26,7 @@ except ImportError:
 from shutil import copy
 
 from datalad.api import Dataset
+
 
 target = {
     "format": "mime:audio/mp3",

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,10 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.7
 install_requires =
     six
-    # uncomment this when datalad is released without metadata code in core: datalad >=0.17.x
+    datalad >= 0.17.6
     datalad-metadata-model >=0.3.5,<0.4.0
     pyyaml
 test_requires =


### PR DESCRIPTION
Fixes #288 

This PR fixes two errors:

1. Fix python and datalad dependency definitions to ensure that test data is contained within the distribution package
2. Ensure selection of `datalad_metalad` contained extractors over extractors with the same name from `datalad`
