### PR TITLE
TST: Don't error out on deprecation warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands = {posargs}
 
 [pytest]
 filterwarnings =
-    error::DeprecationWarning:^datalad
+    ignore::DeprecationWarning:^datalad
     error:.*yield tests:pytest.PytestCollectionWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     # comes from boto


### PR DESCRIPTION
This PR follows the metalad extension failure in https://github.com/datalad/datalad/pull/7170