### PR TITLE
Move MacOS test to monterey

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,7 +86,7 @@ environment:
     # MacOS core tests
     - ID: MacP38
       DTS: datalad_metalad
-      APPVEYOR_BUILD_WORKER_IMAGE: macOS
+      APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
       PY: 3.8
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
@@ -190,8 +190,8 @@ test_script:
   - sh: mkdir __testhome__
   - cd __testhome__
     # run test selection
-  - cmd: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad ..\%DTS%
-  - sh: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad ../${DTS}
+  - cmd: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad --pyargs ..\%DTS%
+  - sh: python -m pytest -c ../tox.ini -s -v --cov=datalad_metalad --pyargs ../${DTS}
 
 
 after_test:
@@ -201,18 +201,19 @@ after_test:
   - cd ..
   - python -m coverage xml
   # Import public codecov key to verify uploader signatures
+
   - sh: pwd
   - sh: ls
   - sh: gpg --no-default-keyring --keyring trustedkeys.gpg --import .codecov.pgp_keys.asc
   - cmd: gpg --no-default-keyring --keyring trustedkeys.gpg --import .codecov.pgp_keys.asc
-  # Fetch latest uploader for linux and macos
+  # Fetch the latest uploader for linux and macos
   - sh: curl -Os https://uploader.codecov.io/latest/${CODECOV_PLATFORM}/codecov
   - sh: curl -Os https://uploader.codecov.io/latest/${CODECOV_PLATFORM}/codecov.SHA256SUM
   - sh: curl -Os https://uploader.codecov.io/latest/${CODECOV_PLATFORM}/codecov.SHA256SUM.sig
   - sh: gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
   - sh: chmod +x codecov
   - sh: ./codecov -f "coverage.xml"
-  # Fetch latest windows codecov.exe
+  # Fetch the latest windows codecov.exe
   - ps: Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
   - ps: Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM -Outfile codecov.exe.SHA256SUM
   - ps: Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig -Outfile codecov.exe.SHA256SUM.sig


### PR DESCRIPTION
This PR uses macos-moneterey image to run MacOS tests on appveyor