### PR TITLE
Check for None Metadata Root Record in search

### DIFF
--- a/datalad_metalad/dump.py
+++ b/datalad_metalad/dump.py
@@ -299,17 +299,10 @@ def dump_from_dataset_tree(mapper: str,
 
             # Create a tree search object to search for the specified datasets
             tree_search = MTreeSearch(dataset_tree.mtree)
-
-            if prefix_path == MetadataPath(""):
-                search_results = tree_search.search_pattern(
-                    pattern=metadata_url.dataset_path,
-                    recursive=recursive,
-                    item_indicator=datalad_root_record_name)
-            else:
-                search_results = tree_search.search_pattern(
-                    pattern=metadata_url.dataset_path,
-                    recursive=recursive,
-                    item_indicator=datalad_root_record_name)
+            search_results = tree_search.search_pattern(
+                pattern=metadata_url.dataset_path,
+                recursive=recursive,
+                item_indicator=datalad_root_record_name)
 
             result_count = 0
             for path, node, _ in search_results:
@@ -318,6 +311,11 @@ def dump_from_dataset_tree(mapper: str,
                 mrr = cast(
                     MetadataRootRecord,
                     node.get_child(datalad_root_record_name))
+
+                if mrr is None:
+                    # The metadata root record might be None, if no dataset
+                    # was registered in the dataset tree at this level.
+                    continue
 
                 yield from show_dataset_metadata(
                     mapper,


### PR DESCRIPTION
Should fix #305 

This PR ensures that metalad checks whether there is actually a metadata root record (MRR) at a certain dataset path-level before trying to dump metadata.

It is wrong to assume that there is always an MRR, because the dataset tree can contain nodes that do not represent a dataset and have therefore no MRR.
