### PR TITLE
Add __generation__ to metadata extractors to be able to tell one from another

### DIFF
--- a/datalad_metalad/__init__.py
+++ b/datalad_metalad/__init__.py
@@ -5,6 +5,9 @@ import hashlib
 
 __docformat__ = 'restructuredtext'
 
+# What generations of the extractors etc are supported by this given version of metalad
+__supported_generations__ = [2, 3, 4]
+
 
 # defines a datalad command suite
 # this symbol must be identified as a setuptools entrypoint

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -62,6 +62,8 @@ class DataOutputCategory(enum.Enum):
 
 class MetadataExtractorBase(metaclass=abc.ABCMeta):
 
+    __generation__ = 'gen4'
+
     @abc.abstractmethod
     def extract(self,
                 output_location: Optional[Union[IO, str]] = None
@@ -243,6 +245,10 @@ class MetadataExtractor(metaclass=abc.ABCMeta):
     # ATM this doesn't do anything, but inheritance from this class enables
     # detection of new-style extractor API
 
+    # associated with times when metadata records collections (ds- vs cn-) were aggregated
+    # within  `.datalad/metadata/aggregate_v1.json` .
+    __generation__ = 'legacy'
+
     @abc.abstractmethod
     def __call__(self,
                  dataset: Dataset,
@@ -337,6 +343,8 @@ class MetadataExtractor(metaclass=abc.ABCMeta):
 # XXX this is the legacy-legacy interface, keep around for a bit more and then
 # remove
 class BaseMetadataExtractor:
+
+    __generation__ = 'legacy-legacy'
 
     NEEDS_CONTENT = True   # majority of the extractors need data content
 

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -62,7 +62,7 @@ class DataOutputCategory(enum.Enum):
 
 class MetadataExtractorBase(metaclass=abc.ABCMeta):
 
-    __generation__ = 'gen4'
+    __generation__ = 4
 
     @abc.abstractmethod
     def extract(self,
@@ -247,7 +247,7 @@ class MetadataExtractor(metaclass=abc.ABCMeta):
 
     # associated with times when metadata records collections (ds- vs cn-) were aggregated
     # within  `.datalad/metadata/aggregate_v1.json` .
-    __generation__ = 'legacy'
+    __generation__ = 3
 
     @abc.abstractmethod
     def __call__(self,
@@ -344,7 +344,7 @@ class MetadataExtractor(metaclass=abc.ABCMeta):
 # remove
 class BaseMetadataExtractor:
 
-    __generation__ = 'legacy-legacy'
+    __generation__ = 2
 
     NEEDS_CONTENT = True   # majority of the extractors need data content
 


### PR DESCRIPTION
This way we could quickly tell one "generation" of things from another. To be used in https://github.com/datalad/datalad-metalad/issues/340 .
I don't mind if later or now it is formalized even better. FWIW in now deprecated `search` we have

```python
        metadata_source=Parameter(
            args=('--metadata-source',),
            choices=('legacy', 'gen4', 'all'),
            doc="""if given, defines which metadata source will be used to
            search. 'legacy' will limit search to metadata in the old format,
            i.e. stored in '$DATASET/.datalad/metadata'. 'gen4' will limit
            search to metadata stored by the git-backend of 
            'datalad-metadata-model'. If 'all' is given, metadata from all
            supported sources will be included in the search. The default is
            'legacy'.""")
```

so I used "compatible" identifiers here.