### PR TITLE
BF: Raise early and informative when extracting from a non-existing file

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -285,6 +285,10 @@ class Extract(Interface):
                         f"dataset given by {source_dataset.pathobj}"
                     )
                 path_object = relative_path
+            if not (source_dataset.pathobj / path_object).exists():
+                raise ValueError(
+                    "To-be-extracted file %s does not exist" % str(path_object)
+                )
 
         _, file_tree_path = get_path_info(source_dataset, path_object, None)
 

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -285,7 +285,10 @@ class Extract(Interface):
                         f"dataset given by {source_dataset.pathobj}"
                     )
                 path_object = relative_path
-            if not (source_dataset.pathobj / path_object).exists():
+            # a basic sanity check: Does the to-be-extracted file exist (as a
+            # file or symlink)
+            if not (source_dataset.pathobj / path_object).exists() and \
+                    not (source_dataset.pathobj / path_object).is_symlink():
                 raise ValueError(
                     "To-be-extracted file %s does not exist" % str(path_object)
                 )

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -629,7 +629,7 @@ def test_path_assembly(temp_dir=None):
 
 
 @with_tempfile(mkdir=True)
-def test_not_tracked_error_catching(temp_dir=None):
+def test_not_existent_error_catching(temp_dir=None):
     # expect a value error, if the provided file is not tracked.
     ds_path = Path(temp_dir) / "dataset"
     ds = Dataset(ds_path).create()


### PR DESCRIPTION
This fixes #354. 
However, its only one step towards a proper solution. As outlined by @mih in the chat, the ``path`` argument of ``meta-extract`` should ideally get a constraint such as ``EnsurePath(lexists=True)`` (https://github.com/datalad/datalad-next/blob/c3f60e9e55ab0d9e77fb5cc2f02479a092445cc8/datalad_next/constraints/basic.py#L328) that can perform this input validation automatically before the command runs. This change is more along the lines of how-we-do-it-in-core (add a series of sanity checks at the start of a command)

Nevertheless, its an improvement from the status quo (which delayed raising the error to the last possible point in time, after an internal status call didn't return a status, and raised it with less informative error about the lack of a dataset status), and would behavior-wise be compatible/identical to what future proper parameter validation would do from the perspective of a user (throw an exception). 

This PR also renames test which implied to test behavior on untracked files, when in reality it tested behavior on non-existing files.