### PR TITLE
Return non-ok result records with a generic result renderer

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -41,6 +41,7 @@ from datalad.interface.base import (
     build_doc,
     eval_results,
 )
+from datalad.interface.utils import generic_result_renderer
 from datalad.support.annexrepo import AnnexRepo
 from datalad.ui import ui
 
@@ -320,7 +321,7 @@ class Extract(Interface):
     @staticmethod
     def custom_result_renderer(res, **kwargs):
         if res["status"] != "ok" or res.get("action", "") != 'meta_extract':
-            # logging complained about this already
+            generic_result_renderer(res)
             return
 
         metadata_record = res.get("metadata_record", None)


### PR DESCRIPTION
Even though the comment says that logging has handled any non-ok, non-meta-extract action, I believe that relying on logging solely is not ok and bad UX. Logging does not ensure that users get to see the log messages. A failure can go entirely unnoticed as users would see nothing returned in their terminal when their configured log level does not match the log level the errors are logged on.