### PR TITLE
ENH: Allow `DatasetMetadataExtractor.get_required_content()` to return a generator

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -472,7 +472,7 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
         failure_count = 0
         for r in res:
             if r["status"] in ("error", "impossible"):
-                failure_count+=1
+                failure_count += 1
                 yield r
         if failure_count > 0:
             return

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -458,10 +458,9 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
     }
 
     # Let the extractor get the files it requires
-    # Handle both possibilities of bool return and Generator yield
+    # Handle both return possibilities of bool and Generator
     res = extractor.get_required_content()
-
-    if isinstance(res, bool) or res is None:
+    if isinstance(res, bool):
         if res is False:
             yield {
                 "status": "impossible",

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -471,7 +471,7 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
     else:
         failure_count = 0
         for r in res:
-            if r['status'] in ["error", "impossible"]:
+            if r["status"] in ("error", "impossible"):
                 failure_count+=1
                 yield r
         if failure_count > 0:

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -460,7 +460,8 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
     # Let the extractor get the files it requires
     # Handle both possibilities of bool return and Generator yield
     res = extractor.get_required_content()
-    if isinstance(res, bool):
+
+    if isinstance(res, bool) or res is None:
         if res is False:
             yield {
                 "status": "impossible",

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -12,8 +12,9 @@ import dataclasses
 import enum
 from typing import (
     Any,
-    IO,
     Dict,
+    Generator,
+    IO,
     List,
     Optional,
     Union,
@@ -158,17 +159,28 @@ class DatasetMetadataExtractor(MetadataExtractorBase, metaclass=abc.ABCMeta):
         self.ref_commit = ref_commit
         self.parameter = parameter or {}
 
-    def get_required_content(self) -> bool:
-        """
-        Let the extractor get the content that it needs locally.
-        The default implementation is to do nothing.
+    def get_required_content(self) -> bool | Generator:
+        """Let the extractor get the content that it needs locally.
+        
+        The default implementation is to do nothing and return True
+        Extractors that overwrite this function can return a boolean
+        (True/False) value OR yield DataLad result records.
 
         Returns
         -------
-        True if all required content could be fetched, False
-        otherwise. If False is returned, the extractor
-        infrastructure will signal an error and the extractor's
-        extract method will not be called.
+        bool
+          True if all required content could be fetched, False
+          otherwise. If False is returned, the extractor
+          infrastructure will signal an error and the extractor's
+          extract method will not be called.
+        
+        Yields
+        ------
+        dict
+          DataLad result records. If a result record is yielded
+          with a failure 'status' (i.e. equal to 'impossible' or
+          'error') the extractor infrastructure will signal an error
+          and the extractor's extract method will not be called.
         """
         return True
 

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -159,7 +159,7 @@ class DatasetMetadataExtractor(MetadataExtractorBase, metaclass=abc.ABCMeta):
         self.ref_commit = ref_commit
         self.parameter = parameter or {}
 
-    def get_required_content(self) -> bool | Generator:
+    def get_required_content(self) -> Union[bool, Generator]:
         """Let the extractor get the content that it needs locally.
         
         The default implementation is to do nothing and return True

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -555,6 +555,7 @@ def test_get_required_content_called(ds_path=None):
 
         def get_required_content(self):
             self.required_content_called = True
+            return True
 
         def get_id(self) -> UUID:
             return UUID(int=10)

--- a/docs/source/user_guide/writing-extractors.rst
+++ b/docs/source/user_guide/writing-extractors.rst
@@ -114,7 +114,7 @@ Example 3::
 
   from typing import Generator
   def get_required_content(self) -> Generator:
-      result = self.dataset.get("CITATION.cff", result_renderer="disabled")
+      result = self.dataset.get('CITATION.cff', result_renderer='disabled')
       failure_count = 0
       result_dict = dict(
           path=self.dataset.path,

--- a/docs/source/user_guide/writing-extractors.rst
+++ b/docs/source/user_guide/writing-extractors.rst
@@ -87,7 +87,7 @@ It will be called by MetaLad prior to metadata extraction.
 Its purpose is to allow the extractor to ensure that content that is required for metadata extraction is present
 (relevant, for example, if some of files to be inspected may be annexed).
 
-The function should either return a boolean value (``True | False``) or yield a ``Generator`` with 
+The function should either return a boolean value (``True | False``) or return a ``Generator`` with 
 `DataLad result records`_. In the case of a boolean value, the function should return ``True`` if
 it has obtained the required content, or confirmed its presence. If it returns ``False``,
 metadata extraction will not proceed. Alternatively, yielding result records provides extractors with

--- a/docs/source/user_guide/writing-extractors.rst
+++ b/docs/source/user_guide/writing-extractors.rst
@@ -122,7 +122,7 @@ Example 3::
       )
       for r in res:
           if r['status'] in ['error', 'impossible']:
-              failure_count+=1
+              failure_count += 1
       if failure_count > 0:
           result_dict.update({
               'status': 'error'


### PR DESCRIPTION
This PR:
- Adds logic to `extract.py` to allow either a returned `bool` or a yielded`Generator` to be interpreted correctly: If an extractor implements logic where any result record is yielded with a failure 'status' (i.e. equal to 'impossible' or 'error') the extractor infrastructure will signal an error and the extractor's extract method will not be called.
- Updates the docstring of `DatasetMetadataExtractor.get_required_content()` in `extractors/base.by` to indicate this change, especially to developers implementing extractors 
- Adds missing `return` statements in `extract.py` where failures are yielded
- Updates related documentation
- Closes https://github.com/datalad/datalad-metalad/issues/356
