### PR TITLE
MNT: Refactor extraction code

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -364,7 +364,7 @@ def do_extraction(ep: ExtractionArguments, extractor_type: str):
             "extraction for %s at %s",
             extractor_type,
             extractor_type,
-            ep.source_dataset.path / ep.file_tree_path \
+            ep.source_dataset.path / ep.file_tree_path
             if extractor_type == 'file' else ep.source_dataset.path)
 
         yield from legacy_extractor_map[extractor_type](ep)

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -310,7 +310,7 @@ class Extract(Interface):
         # requested and the extractor class is a subclass of
         # DatasetMetadataExtractor (or a legacy extractor class).
         if path:
-            extractor_type = 'file'
+            extraction_arguments.extractor_type = 'file'
             # Check whether the path points to a sub_dataset.
             ensure_path_validity(source_dataset, file_tree_path)
         else:

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -351,7 +351,8 @@ class Extract(Interface):
             ui.message(json.dumps(context))
 
 
-def do_extraction(ep: ExtractionArguments, extractor_type: str):
+def do_extraction(ep: ExtractionArguments):
+    extractor_type = ep.extractor_type    
 
     # Legacy extraction
     legacy_extractor_map = {

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -314,7 +314,7 @@ class Extract(Interface):
             # Check whether the path points to a sub_dataset.
             ensure_path_validity(source_dataset, file_tree_path)
         else:
-            extractor_type = 'dataset'
+            extraction_arguments.extractor_type = 'dataset'
         
         yield from do_extraction(ep=extraction_arguments, extractor_type=extractor_type)
         return

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -83,6 +83,7 @@ class ExtractionArguments:
     source_dataset_version: str
     local_source_object_path: Path
     extractor_class: Union[type(MetadataExtractor), type(FileMetadataExtractor)]
+    extractor_type: str
     extractor_name: str
     extraction_parameter: Dict[str, str]
     file_tree_path: Optional[MetadataPath]
@@ -297,6 +298,7 @@ class Extract(Interface):
             local_source_object_path=(
                     source_dataset.pathobj / file_tree_path).absolute(),
             extractor_class=extractor_class,
+            extractor_type=None,
             extractor_name=extractor_name,
             extraction_parameter=args_to_dict(extractor_args),
             file_tree_path=file_tree_path,
@@ -316,7 +318,7 @@ class Extract(Interface):
         else:
             extraction_arguments.extractor_type = 'dataset'
         
-        yield from do_extraction(ep=extraction_arguments, extractor_type=extractor_type)
+        yield from do_extraction(ep=extraction_arguments)
         return
 
     @staticmethod

--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -310,11 +310,13 @@ class Extract(Interface):
         # requested and the extractor class is a subclass of
         # DatasetMetadataExtractor (or a legacy extractor class).
         if path:
+            extractor_type = 'file'
             # Check whether the path points to a sub_dataset.
             ensure_path_validity(source_dataset, file_tree_path)
-            yield from do_file_extraction(extraction_arguments)
         else:
-            yield from do_dataset_extraction(extraction_arguments)
+            extractor_type = 'dataset'
+        
+        yield from do_extraction(ep=extraction_arguments, extractor_type=extractor_type)
         return
 
     @staticmethod
@@ -349,116 +351,82 @@ class Extract(Interface):
             ui.message(json.dumps(context))
 
 
-def do_dataset_extraction(ep: ExtractionArguments):
+def do_extraction(ep: ExtractionArguments, extractor_type: str):
 
+    # Legacy extraction
+    legacy_extractor_map = {
+        'file': legacy_extract_file,
+        'dataset': legacy_extract_dataset,
+    }
     if not issubclass(ep.extractor_class, MetadataExtractorBase):
-
         lgr.debug(
-            "performing legacy dataset level metadata "
-            "extraction for dataset at at %s",
-            ep.source_dataset.path)
+            "performing legacy %s-level metadata "
+            "extraction for %s at %s",
+            extractor_type,
+            extractor_type,
+            ep.source_dataset.path / ep.file_tree_path \
+            if extractor_type == 'file' else ep.source_dataset.path)
 
-        yield from legacy_extract_dataset(ep)
+        yield from legacy_extractor_map[extractor_type](ep)
         return
-
-    if not issubclass(ep.extractor_class, DatasetMetadataExtractor):
-        raise ValueError(
-            "A dataset-level metadata-extraction was attempted (since no "
-            "path argument was given), but the specified extractor "
-            f"({ep.extractor_name}) is not a dataset-level extractor.")
-
+    
+    # Latest generation extraction
+    extractor_class_map = {
+        'file': FileMetadataExtractor,
+        'dataset': DatasetMetadataExtractor,
+    }
+    if not issubclass(ep.extractor_class, extractor_class_map[extractor_type]):
+        msg = (
+            f"A {extractor_type}-level metadata-extraction was attempted",
+            "since no path argument was given" if extractor_type == 'dataset' else "",
+            f"but the specified extractor ({ep.extractor_name})",
+            f"is not a {extractor_type}-level extractor"
+        )
+        raise ValueError(msg)
+    
     lgr.debug(
-        "extracting dataset level metadata for dataset at %s",
-        ep.source_dataset.path)
-
-    extractor = ep.extractor_class(
+            "performing %s-level metadata "
+            "extraction for %s at %s",
+            extractor_type,
+            extractor_type,
+            ep.source_dataset.path / ep.file_tree_path \
+            if extractor_type == 'file' else ep.source_dataset.path)
+    
+    if extractor_type == 'file':
+        file_info = get_file_info(ep.source_dataset, ep.file_tree_path)
+        extractor = ep.extractor_class(
+            ep.source_dataset,
+            ep.source_dataset_version,
+            file_info,
+            ep.extraction_parameter)
+        ensure_content_availability(extractor, file_info)
+    else:
+        extractor = ep.extractor_class(
         ep.source_dataset,
         ep.source_dataset_version,
         ep.extraction_parameter)
 
-    yield from perform_dataset_metadata_extraction(ep, extractor)
+    yield from perform_metadata_extraction(ep, extractor)
 
 
-def do_file_extraction(ep: ExtractionArguments):
-
-    if not issubclass(ep.extractor_class, MetadataExtractorBase):
-
-        lgr.debug(
-            "performing legacy file level metadata "
-            "extraction for file at %s/%s",
-            ep.source_dataset.path,
-            ep.file_tree_path)
-
-        yield from legacy_extract_file(ep)
-        return
-
-    if not issubclass(ep.extractor_class, FileMetadataExtractor):
-
-        raise ValueError(
-            "A file-level metadata-extraction was attempted, but the "
-            f"specified extractor ({ep.extractor_name}) is not a "
-            f"file-level extractor.")
-
-    lgr.debug(
-        "performing file level extracting for file at %s/%s",
-        ep.source_dataset.path,
-        ep.file_tree_path)
-
-    file_info = get_file_info(ep.source_dataset, ep.file_tree_path)
-    extractor = ep.extractor_class(
-        ep.source_dataset,
-        ep.source_dataset_version,
-        file_info,
-        ep.extraction_parameter)
-
-    ensure_content_availability(extractor, file_info)
-
-    yield from perform_file_metadata_extraction(ep, extractor)
-
-
-def perform_file_metadata_extraction(extraction_arguments: ExtractionArguments,
-                                     extractor: FileMetadataExtractor):
-
+def perform_metadata_extraction(
+        ep: ExtractionArguments,
+        extractor: Union[DatasetMetadataExtractor, FileMetadataExtractor]
+    ):
+    
+    # Get output category; only IMMEDIATE is supported
     output_category = extractor.get_data_output_category()
     if output_category != DataOutputCategory.IMMEDIATE:
         raise NotImplementedError(
             f"Output category {output_category} not supported")
-
-    result = extractor.extract(None)
-    result.datalad_result_dict["action"] = "meta_extract"
-    result.datalad_result_dict["path"] = extraction_arguments.local_source_object_path
-    if result.extraction_success:
-        result.datalad_result_dict["metadata_record"] = dict(
-            type="file",
-            dataset_id=extraction_arguments.source_dataset_id,
-            dataset_version=extraction_arguments.source_dataset_version,
-            path=extraction_arguments.file_tree_path,
-            extractor_name=extraction_arguments.extractor_name,
-            extractor_version=extractor.get_version(),
-            extraction_parameter=extraction_arguments.extraction_parameter,
-            extraction_time=time.time(),
-            agent_name=extraction_arguments.agent_name,
-            agent_email=extraction_arguments.agent_email,
-            extracted_metadata=result.immediate_data)
-
-    yield result.datalad_result_dict
-
-
-def perform_dataset_metadata_extraction(ep: ExtractionArguments,
-                                        extractor: DatasetMetadataExtractor):
-
-    output_category = extractor.get_data_output_category()
-    if output_category != DataOutputCategory.IMMEDIATE:
-        raise NotImplementedError(
-            f"Output category {output_category} not supported")
-
+    
+    # Prepare result record
     result_template = {
         "action": "meta_extract",
         "path": ep.local_source_object_path
     }
-
-    # Let the extractor get the files it requires
-    # Handle both return possibilities of bool and Generator
+    
+    # Get required content
     res = extractor.get_required_content()
     if isinstance(res, bool):
         if res is False:
@@ -475,8 +443,8 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
                 yield r
         if failure_count > 0:
             return
-
-    # Process results
+    
+    # Run extraction and update result
     result = extractor.extract(None)
     result.datalad_result_dict.update(result_template)
     if result.extraction_success:
@@ -491,7 +459,11 @@ def perform_dataset_metadata_extraction(ep: ExtractionArguments,
             agent_name=ep.agent_name,
             agent_email=ep.agent_email,
             extracted_metadata=result.immediate_data)
-
+        if issubclass(ep.extractor_class, FileMetadataExtractor):
+            result.datalad_result_dict["metadata_record"].update(
+                dict(path=ep.file_tree_path)
+            )
+    
     yield result.datalad_result_dict
 
 

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -104,6 +104,32 @@ class MetadataExtractorBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_data_output_category(self) -> DataOutputCategory:
         raise NotImplementedError
+    
+    def get_required_content(self) -> Union[bool, Generator]:
+        """Let the extractor get the content that it needs locally.
+        
+        The default implementation is to do nothing and return True
+        Extractors that overwrite this function can return a boolean
+        (True/False) value OR yield DataLad result records.
+
+        Returns
+        -------
+        bool
+          True if all required content could be fetched, False
+          otherwise. If False is returned, the extractor
+          infrastructure will signal an error and the extractor's
+          extract method will not be called.
+        
+        Yields
+        ------
+        dict
+          DataLad result records. If a result record is yielded
+          with a failure 'status' (i.e. equal to 'impossible' or
+          'error') the extractor infrastructure will signal an error
+          and the extractor's extract method will not be called.
+        """
+        print("getting required content")
+        return True
 
     def get_state(self, dataset):
         """Report on extractor-related state and configuration
@@ -158,31 +184,6 @@ class DatasetMetadataExtractor(MetadataExtractorBase, metaclass=abc.ABCMeta):
         self.dataset = dataset
         self.ref_commit = ref_commit
         self.parameter = parameter or {}
-
-    def get_required_content(self) -> Union[bool, Generator]:
-        """Let the extractor get the content that it needs locally.
-        
-        The default implementation is to do nothing and return True
-        Extractors that overwrite this function can return a boolean
-        (True/False) value OR yield DataLad result records.
-
-        Returns
-        -------
-        bool
-          True if all required content could be fetched, False
-          otherwise. If False is returned, the extractor
-          infrastructure will signal an error and the extractor's
-          extract method will not be called.
-        
-        Yields
-        ------
-        dict
-          DataLad result records. If a result record is yielded
-          with a failure 'status' (i.e. equal to 'impossible' or
-          'error') the extractor infrastructure will signal an error
-          and the extractor's extract method will not be called.
-        """
-        return True
 
 
 class FileMetadataExtractor(MetadataExtractorBase, metaclass=abc.ABCMeta):

--- a/datalad_metalad/extractors/base.py
+++ b/datalad_metalad/extractors/base.py
@@ -128,7 +128,6 @@ class MetadataExtractorBase(metaclass=abc.ABCMeta):
           'error') the extractor infrastructure will signal an error
           and the extractor's extract method will not be called.
         """
-        print("getting required content")
         return True
 
     def get_state(self, dataset):

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -17,7 +17,10 @@ from typing import (
     Optional,
     Union,
 )
-from unittest.mock import patch
+from unittest.mock import (
+    ANY,
+    patch
+)
 from uuid import UUID
 
 from datalad.api import (
@@ -326,17 +329,14 @@ def test_path_parameter_directory(ds_path=None):
 def test_path_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
-
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
             path="sub/one",
             **common_kwargs)
-        eq_(fe.call_count, 1)
-        eq_(de.call_count, 0)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='file')
 
 
 @with_tree(meta_tree)
@@ -344,9 +344,7 @@ def test_extra_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
@@ -354,11 +352,10 @@ def test_extra_parameter_recognition(ds_path=None):
             path="k1",
             extractorargs=["v1", "k2", "v2", "k3", "v3"],
             **common_kwargs)
-
-        eq_(fe.call_count, 0)
-        eq_(de.call_count, 1)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='dataset')
         eq_(
-            de.call_args_list[0][0][0].extraction_parameter,
+            do_extr.call_args_list[0][1]['ep'].extraction_parameter,
             {
                 "k1": "v1",
                 "k2": "v2",
@@ -371,20 +368,17 @@ def test_path_and_extra_parameter_recognition(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
             path="sub/one",
             extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
             **common_kwargs)
-
-        eq_(de.call_count, 0)
-        eq_(fe.call_count, 1)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='file')
         eq_(
-            fe.call_args_list[0][0][0].extraction_parameter,
+            do_extr.call_args_list[0][1]['ep'].extraction_parameter,
             {
                 "k1": "v1",
                 "k2": "v2",
@@ -396,20 +390,17 @@ def test_path_and_extra_parameter_recognition(ds_path=None):
 def test_context_dict_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
-
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+        
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
             context={"dataset_version": "xyz"},
             path="sub/one",
             **common_kwargs)
-
-        eq_(fe.call_count, 1)
-        eq_(fe.call_args[0][0].source_dataset_version, "xyz")
-        eq_(de.call_count, 0)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='file')
+        eq_(do_extr.call_args[1]['ep'].source_dataset_version, "xyz")
 
 
 @with_tree(meta_tree)
@@ -417,19 +408,16 @@ def test_context_str_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
             context='{"dataset_version": "rst"}',
             path="sub/one",
             **common_kwargs)
-
-        eq_(fe.call_count, 1)
-        eq_(fe.call_args[0][0].source_dataset_version, "rst")
-        eq_(de.call_count, 0)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='file')
+        eq_(do_extr.call_args[1]['ep'].source_dataset_version, "rst")
 
 
 @with_tree(meta_tree)
@@ -464,9 +452,7 @@ def test_extractor_parameter_handling(ds_path=None):
 
     ds = _create_dataset_at_path(ds_path)
 
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-         patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_dataset",
             dataset=ds,
@@ -474,25 +460,21 @@ def test_extractor_parameter_handling(ds_path=None):
             path="k0",
             extractorargs=["v0", "k1", "v1"],
             **common_kwargs)
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='dataset')
+        eq_(do_extr.call_args[1]['ep'].extraction_parameter, {"k0": "v0", "k1": "v1"})
 
-        eq_(fe.call_count, 0)
-        eq_(de.call_count, 1)
-        eq_(de.call_args[0][0].extraction_parameter, {"k0": "v0", "k1": "v1"})
-
-    with patch("datalad_metalad.extract.do_file_extraction") as fe, \
-            patch("datalad_metalad.extract.do_dataset_extraction") as de:
-
+    with patch("datalad_metalad.extract.do_extraction") as do_extr:
         meta_extract(
             extractorname="metalad_example_file",
             dataset=ds,
             path="sub/one",
             extractorargs=["k0", "v0", "k1", "v1"],
             **common_kwargs)
-
-        eq_(de.call_count, 0)
-        eq_(fe.call_count, 1)
-        eq_(fe.call_args[0][0].file_tree_path, MetadataPath("sub/one"))
-        eq_(fe.call_args[0][0].extraction_parameter, {"k0": "v0", "k1": "v1"})
+        eq_(do_extr.call_count, 1)
+        do_extr.assert_called_with(ep=ANY, extractor_type='file')
+        eq_(do_extr.call_args[1]['ep'].file_tree_path, MetadataPath("sub/one"))
+        eq_(do_extr.call_args[1]['ep'].extraction_parameter, {"k0": "v0", "k1": "v1"})
 
 
 @with_tree(meta_tree)
@@ -609,7 +591,7 @@ def test_path_assembly(temp_dir=None):
             extractorname="metalad_core",
             path=str(file_path)
         )
-        extraction_arguments = dfe_mock.call_args[0][0]
+        extraction_arguments = dfe_mock.call_args[1]['ep']
         eq_(extraction_arguments.local_source_object_path, file_path.absolute())
         eq_(extraction_arguments.file_tree_path, MetadataPath(expected_path))
 
@@ -623,7 +605,7 @@ def test_path_assembly(temp_dir=None):
     ds.save(**common_kwargs)
 
     with chpwd(str(subdir_path)):
-        with patch("datalad_metalad.extract.do_file_extraction") as dfe_mock:
+        with patch("datalad_metalad.extract.do_extraction") as dfe_mock:
             # Check absolute path
             check_with_file_path(dfe_mock, file_path.absolute(), "sub1/info.txt")
             check_with_file_path(dfe_mock, file_path, "sub1/info.txt")

--- a/datalad_metalad/tests/test_extract.py
+++ b/datalad_metalad/tests/test_extract.py
@@ -17,10 +17,7 @@ from typing import (
     Optional,
     Union,
 )
-from unittest.mock import (
-    ANY,
-    patch
-)
+from unittest.mock import patch
 from uuid import UUID
 
 from datalad.api import (
@@ -336,7 +333,7 @@ def test_path_parameter_recognition(ds_path=None):
             path="sub/one",
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='file')
+        eq_(do_extr.call_args[1]['ep'].extractor_type, 'file')
 
 
 @with_tree(meta_tree)
@@ -353,7 +350,7 @@ def test_extra_parameter_recognition(ds_path=None):
             extractorargs=["v1", "k2", "v2", "k3", "v3"],
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='dataset')
+        eq_(do_extr.call_args[1]['ep'].extractor_type, 'dataset')
         eq_(
             do_extr.call_args_list[0][1]['ep'].extraction_parameter,
             {
@@ -376,7 +373,6 @@ def test_path_and_extra_parameter_recognition(ds_path=None):
             extractorargs=["k1", "v1", "k2", "v2", "k3", "v3"],
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='file')
         eq_(
             do_extr.call_args_list[0][1]['ep'].extraction_parameter,
             {
@@ -399,7 +395,6 @@ def test_context_dict_parameter_handling(ds_path=None):
             path="sub/one",
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='file')
         eq_(do_extr.call_args[1]['ep'].source_dataset_version, "xyz")
 
 
@@ -416,7 +411,6 @@ def test_context_str_parameter_handling(ds_path=None):
             path="sub/one",
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='file')
         eq_(do_extr.call_args[1]['ep'].source_dataset_version, "rst")
 
 
@@ -461,7 +455,7 @@ def test_extractor_parameter_handling(ds_path=None):
             extractorargs=["v0", "k1", "v1"],
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='dataset')
+        eq_(do_extr.call_args[1]['ep'].extractor_type, 'dataset')
         eq_(do_extr.call_args[1]['ep'].extraction_parameter, {"k0": "v0", "k1": "v1"})
 
     with patch("datalad_metalad.extract.do_extraction") as do_extr:
@@ -472,7 +466,6 @@ def test_extractor_parameter_handling(ds_path=None):
             extractorargs=["k0", "v0", "k1", "v1"],
             **common_kwargs)
         eq_(do_extr.call_count, 1)
-        do_extr.assert_called_with(ep=ANY, extractor_type='file')
         eq_(do_extr.call_args[1]['ep'].file_tree_path, MetadataPath("sub/one"))
         eq_(do_extr.call_args[1]['ep'].extraction_parameter, {"k0": "v0", "k1": "v1"})
 


### PR DESCRIPTION
This PR:
- moves the `get_required_content` method to the base class `MetadataExtractorBase` so that both `FileMetadataExtractor` and `DatasetMetadataExtractor` can make use of it (addresses https://github.com/datalad/datalad-metalad/issues/287)
- refactors `extract.py` in order to deduplicate code, and updates related tests (addresses https://github.com/datalad/datalad-metalad/issues/366):
   - merges `do_file_extraction()` and `do_dataset_extraction()` into a single function `do_extraction()`, with a new argument `extractor_type`, which would be either `'file'` or `'dataset'`.
   - merges `perform_file_metadata_extraction()` and `perform_dataset_metadata_extraction()` into a single function `perform_metadata_extraction()`