### PR TITLE
BUG: fix extractor type in `metadata_record`

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -466,7 +466,10 @@ def perform_metadata_extraction(
             extracted_metadata=result.immediate_data)
         if issubclass(ep.extractor_class, FileMetadataExtractor):
             result.datalad_result_dict["metadata_record"].update(
-                dict(path=ep.file_tree_path)
+                dict(
+                    type="file",
+                    path=ep.file_tree_path,
+                )
             )
     
     yield result.datalad_result_dict


### PR DESCRIPTION
This was supposed to be part of https://github.com/datalad/datalad-metalad/pull/367, but fell through the cracks. This addition ensures that the correct type is displayed in the metadata record output from `meta-extract`