### PR TITLE
BF: imports `BaseMetadataExtractor` from `datalad-deprecated`

### DIFF
--- a/datalad_metalad/extract.py
+++ b/datalad_metalad/extract.py
@@ -45,7 +45,6 @@ from datalad.support.annexrepo import AnnexRepo
 from datalad.ui import ui
 
 from .extractors.base import (
-    BaseMetadataExtractor,
     DataOutputCategory,
     DatasetMetadataExtractor,
     FileInfo,
@@ -53,6 +52,8 @@ from .extractors.base import (
     MetadataExtractor,
     MetadataExtractorBase,
 )
+
+from datalad_deprecated.metadata.extractors.base import BaseMetadataExtractor
 
 from datalad.support.constraints import (
     EnsureNone,

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     six
     datalad >= 0.18
     datalad-metadata-model >=0.3.10
+    datalad-deprecated
     pytest
     pyyaml
 test_requires =


### PR DESCRIPTION
Fixes https://github.com/datalad/datalad-metalad/issues/376