### PR TITLE
Replace `pkg_rsources` with `importlib.metadata`

### DIFF
--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -8,9 +8,13 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """Test all extractors at a basic level"""
 
-from pkg_resources import iter_entry_points
+import sys
 
 import pytest
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 from datalad.api import (
     Dataset,
@@ -47,7 +51,7 @@ def test_api(path=None, *, annex):
     assert_repo_status(ds.path)
 
     processed_extractors, skipped_extractors = [], []
-    for extractor_ep in iter_entry_points("datalad.metadata.extractors"):
+    for extractor_ep in entry_points(group="datalad.metadata.extractors"):
 
         # There are a number of extractors that do not
         # work on empty datasets, or datasets, or without

--- a/datalad_metalad/filter.py
+++ b/datalad_metalad/filter.py
@@ -12,6 +12,7 @@ Run a metadata filter on a set of metadata elements
 import json
 import logging
 from pathlib import Path
+import sys
 from typing import (
     Dict,
     Iterable,
@@ -285,10 +286,13 @@ def run_filter(filter_name: str,
 
 def get_filter_class(filter_name: str) -> Type[MetadataFilterBase]:
     """ Get a filter class from its name"""
-    from pkg_resources import iter_entry_points
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
 
     entry_points = list(
-        iter_entry_points("datalad.metadata.filters", filter_name))
+        entry_points(group="datalad.metadata.filters", name=filter_name))
 
     if not entry_points:
         raise ValueError(
@@ -299,7 +303,7 @@ def get_filter_class(filter_name: str) -> Type[MetadataFilterBase]:
     lgr.debug(
         "Using metadata filter %s from distribution %s",
         filter_name,
-        entry_point.dist.project_name)
+        entry_point.dist.name)
 
     # Inform about overridden entry points
     for ignored_entry_point in ignored_entry_points:
@@ -307,8 +311,8 @@ def get_filter_class(filter_name: str) -> Type[MetadataFilterBase]:
             "MetadataRecord filter %s from distribution %s overrides "
             "metadata filter from distribution %s",
             filter_name,
-            entry_point.dist.project_name,
-            ignored_entry_point.dist.project_name)
+            entry_point.dist.name,
+            ignored_entry_point.dist.name)
 
     return entry_point.load()
 

--- a/datalad_metalad/utils.py
+++ b/datalad_metalad/utils.py
@@ -1,9 +1,13 @@
 import json
-import pkg_resources
 import sys
 from itertools import islice
 from pathlib import Path
 from typing import Dict, List, Union
+
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 from datalad.distribution.dataset import (
     Dataset,
@@ -82,8 +86,7 @@ def read_json_object(path_or_object: Union[str, JSONType]) -> JSONType:
         else:
             try:
                 json_object = json.loads(
-                    pkg_resources.resource_string(
-                        "datalad_metalad.pipeline",
+                    files("datalad_metalad.pipeline").joinpath(
                         f"pipelines/{path_or_object}_pipeline.json"))
                 return json_object
             except FileNotFoundError:

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,7 @@
 coverage
 datalad>=0.18
 datalad-metadata-model>=0.3.10
+importlib-resources
 sphinx>=1.7.8
 sphinx-rtd-theme
 pre-commit


### PR DESCRIPTION
This PR replaces the deprecated and removed `pkg_resources` with `importlib.metadata`. This PR fixes issue #397