### PR TITLE
Specify minimum version of `importlib-metadata` and `importlib-resources`

### DIFF
--- a/datalad_metalad/extractors/tests/test_base.py
+++ b/datalad_metalad/extractors/tests/test_base.py
@@ -11,7 +11,7 @@
 import sys
 
 import pytest
-if sys.version_info < (3, 9):
+if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
     from importlib.metadata import entry_points

--- a/datalad_metalad/filter.py
+++ b/datalad_metalad/filter.py
@@ -286,7 +286,7 @@ def run_filter(filter_name: str,
 
 def get_filter_class(filter_name: str) -> Type[MetadataFilterBase]:
     """ Get a filter class from its name"""
-    if sys.version_info < (3, 9):
+    if sys.version_info < (3, 10):
         from importlib_metadata import entry_points
     else:
         from importlib.metadata import entry_points

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,8 +1,8 @@
 coverage
 datalad>=0.18
 datalad-metadata-model>=0.3.10
-importlib-resources
-importlib-metadata
+importlib-metadata>=3.6; python_version < '3.10'
+importlib-resources>=3.0; python_version < '3.9'
 sphinx>=1.7.8
 sphinx-rtd-theme
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 datalad>=0.18
 datalad-metadata-model>=0.3.10
-importlib-resources
-importlib-metadata
+importlib-metadata>=3.6; python_version < '3.10'
+importlib-resources>=3.0; python_version < '3.9'
 pytest
 pyyaml
 sphinx>=1.7.8


### PR DESCRIPTION
This PR specifies minimum versions for `importlib-metadata` and `importlib-resources`.
